### PR TITLE
Add servant model launcher script

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -503,6 +503,15 @@ GLM‑4.1V‑9B weights are present and starts a local API compatible with the
 ./crown_model_launcher.sh
 ```
 
+Run `launch_servants.sh` to start additional models defined in
+`secrets.env`. The script checks `DEEPSEEK_URL`, `MISTRAL_URL` and
+`KIMI_K2_URL`; if any of them point to a localhost URL the respective model
+is launched using Docker or `vllm`.
+
+```bash
+./launch_servants.sh
+```
+
 Once the service is running you can start the REPL:
 
 ```bash

--- a/launch_servants.sh
+++ b/launch_servants.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Launch servant LLMs when configured with localhost URLs
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT"
+
+if [ -f "secrets.env" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "secrets.env"
+    set +a
+else
+    echo "secrets.env not found" >&2
+    exit 1
+fi
+
+launch_model() {
+    local name="$1"
+    local url="$2"
+    local model_dir="$3"
+    local image="$4"
+
+    if [ -z "$url" ]; then
+        return
+    fi
+
+    if [[ "$url" == http://localhost:* || "$url" == http://127.0.0.1:* ]]; then
+        local port="${url##*:}"
+        port="${port%%/*}"
+        if [ ! -d "$model_dir" ]; then
+            case "$name" in
+                deepseek)
+                    python download_models.py deepseek_v3 ;;
+                mistral)
+                    python download_models.py mistral_8x22b --int8 ;;
+                kimi_k2)
+                    python download_models.py kimi_k2 ;;
+            esac
+        fi
+        if command -v docker >/dev/null 2>&1; then
+            docker run -d --rm -v "$model_dir":/model -p "$port":8000 \
+                --name "${name}_service" "$image"
+        else
+            python -m vllm.entrypoints.openai.api_server \
+                --model "$model_dir" --port "$port" &
+        fi
+    fi
+}
+
+launch_model deepseek "${DEEPSEEK_URL:-}" "INANNA_AI/models/DeepSeek-V3" "deepseek-service:latest"
+launch_model mistral "${MISTRAL_URL:-}" "INANNA_AI/models/Mistral-8x22B" "mistral-service:latest"
+launch_model kimi_k2 "${KIMI_K2_URL:-}" "INANNA_AI/models/Kimi-K2" "kimi-k2-service:latest"


### PR DESCRIPTION
## Summary
- add a helper script `launch_servants.sh` to spawn DeepSeek, Mistral and Kimi models
- document the script in the "Crown Agent Console" section

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687923555a58832ebbdb608efc59bb4a