### PR TITLE
Add Crown console startup script

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -512,6 +512,13 @@ is launched using Docker or `vllm`.
 ./launch_servants.sh
 ```
 
+Use `start_crown_console.sh` to launch these services and automatically
+open the interactive console once the endpoints are ready.
+
+```bash
+./start_crown_console.sh
+```
+
 Once the service is running you can start the REPL:
 
 ```bash

--- a/start_crown_console.sh
+++ b/start_crown_console.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Launch Crown services and start the console
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT"
+
+if [ -f "secrets.env" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "secrets.env"
+    set +a
+else
+    echo "secrets.env not found" >&2
+    exit 1
+fi
+
+./crown_model_launcher.sh
+
+if [ -f "launch_servants.sh" ]; then
+    ./launch_servants.sh
+fi
+
+wait_port() {
+    local port=$1
+    printf 'Waiting for port %s...\n' "$port"
+    while ! nc -z localhost "$port"; do
+        sleep 1
+    done
+}
+
+parse_port() {
+    local url=$1
+    local port="${url##*:}"
+    echo "${port%%/*}"
+}
+
+main_port=$(parse_port "$GLM_API_URL")
+wait_port "$main_port"
+
+for url in "${DEEPSEEK_URL:-}" "${MISTRAL_URL:-}" "${KIMI_K2_URL:-}"; do
+    if [[ "$url" == http://localhost:* || "$url" == http://127.0.0.1:* ]]; then
+        wait_port "$(parse_port "$url")"
+    fi
+done
+
+python console_interface.py


### PR DESCRIPTION
## Summary
- add `start_crown_console.sh` to launch Crown models and open the console
- document the new script in `README_OPERATOR.md`

## Testing
- `pytest tests/test_crown_initialization.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687924998f98832e84fae90b2638068a