### PR TITLE
Add optional servant model services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,27 @@ services:
       - CORPUS_MEMORY_PATH=/home/inanna/app/data/corpus_memory.json
     command: bash -c "./crown_model_launcher.sh & python start_spiral_os.py"
     restart: unless-stopped
+
+  deepseek:
+    image: deepseek-service:latest
+    ports:
+      - "8002:8000"
+    volumes:
+      - ./INANNA_AI/models/DeepSeek-V3:/model
+    restart: unless-stopped
+
+  mistral:
+    image: mistral-service:latest
+    ports:
+      - "8003:8000"
+    volumes:
+      - ./INANNA_AI/models/Mistral-8x22B:/model
+    restart: unless-stopped
+
+  kimi_k2:
+    image: kimi-k2-service:latest
+    ports:
+      - "8010:8000"
+    volumes:
+      - ./INANNA_AI/models/Kimi-K2:/model
+    restart: unless-stopped

--- a/docs/deployment_overview.md
+++ b/docs/deployment_overview.md
@@ -49,7 +49,16 @@ To test locally without Vast.ai simply run:
 docker-compose up
 ```
 
-The compose file builds the two services, mounts `data` and `logs`, and exposes ports `8000` and `3001`. Once the containers are running open `web_console/index.html` to issue commands through the FastAPI endpoint.
+The compose file builds the main `INANNA_AI` container and mounts `data`, `logs` and `INANNA_AI/models`. Optional `deepseek`, `mistral` and `kimi_k2` services are also defined. Each exposes its own port and expects a corresponding model directory:
+
+```
+INANNA_AI  -> 8000/8001  INANNA_AI/models
+deepseek   -> 8002       INANNA_AI/models/DeepSeek-V3
+mistral    -> 8003       INANNA_AI/models/Mistral-8x22B
+kimi_k2    -> 8010       INANNA_AI/models/Kimi-K2
+```
+
+Run `docker-compose up` to start everything or specify a subset such as `docker-compose up INANNA_AI deepseek`. Once running, open `web_console/index.html` to issue commands through the FastAPI endpoint.
 
 For details on browser permissions see
 [how_to_use.md](how_to_use.md#connecting-via-webrtc).


### PR DESCRIPTION
## Summary
- expose DeepSeek, Mistral and Kimi‑K2 services in `docker-compose.yml`
- describe optional containers and ports in deployment guide

## Testing
- `pytest tests/test_download_models.py::test_main_deepseek_calls_download -q`


------
https://chatgpt.com/codex/tasks/task_e_6879294f0320832eb63810707cef5a6e