### PR TITLE
Add RAG parser utility

### DIFF
--- a/rag_parser.py
+++ b/rag_parser.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Utility to parse directories into text chunks for RAG."""
+
+from pathlib import Path
+from typing import Dict, List
+import argparse
+
+
+def load_inputs(source_dir: Path) -> List[Dict[str, str]]:
+    """Return chunks of text from files under ``source_dir``."""
+    exts = {".md", ".txt", ".py", ".ipynb", ".json"}
+    items: List[Dict[str, str]] = []
+    for path in source_dir.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in exts:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            continue
+        rel_parts = path.relative_to(source_dir).parts
+        archetype = rel_parts[0] if len(rel_parts) > 1 else None
+        chunk_size = 2000
+        for i in range(0, len(text), chunk_size):
+            chunk = text[i : i + chunk_size]
+            item: Dict[str, str] = {
+                "text": chunk,
+                "source_path": str(path),
+            }
+            if archetype:
+                item["archetype"] = archetype
+            items.append(item)
+    return items
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="rag_parser")
+    parser.add_argument("--dir", default="sacred_inputs", help="Directory to load")
+    args = parser.parse_args(argv)
+    chunks = load_inputs(Path(args.dir))
+    print(len(chunks))
+    return 0
+
+
+__all__ = ["load_inputs", "main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    raise SystemExit(main())

--- a/tests/test_rag_parser.py
+++ b/tests/test_rag_parser.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import rag_parser
+
+
+def test_load_inputs_chunking(tmp_path):
+    base = tmp_path
+    # Root file
+    (base / "test.txt").write_text("hello", encoding="utf-8")
+    # JSON
+    (base / "data.json").write_text('{"a": 1}', encoding="utf-8")
+    # Notebook
+    (base / "nb.ipynb").write_text("{}", encoding="utf-8")
+    # Archetype folder
+    arch = base / "alpha"
+    arch.mkdir()
+    (arch / "doc.md").write_text("content", encoding="utf-8")
+    long_text = "x" * 2100
+    (arch / "code.py").write_text(long_text, encoding="utf-8")
+
+    res = rag_parser.load_inputs(base)
+    assert len(res) == 6
+
+    code_chunks = [c for c in res if Path(c["source_path"]).name == "code.py"]
+    assert len(code_chunks) == 2
+    assert len(code_chunks[0]["text"]) == 2000
+    assert len(code_chunks[1]["text"]) == 100
+
+    alpha_items = [c for c in res if c.get("archetype") == "alpha"]
+    assert alpha_items


### PR DESCRIPTION
## Summary
- add `sacred_inputs/` directory placeholder
- implement `rag_parser.py` for directory chunking
- expose simple CLI for chunk counts
- test parsing & chunking behaviour

## Testing
- `python rag_parser.py --dir sacred_inputs`
- `pytest tests/test_rag_parser.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6879305b07f8832e93d13101c108943b