### PR TITLE
Add spiral_vector_db helper

### DIFF
--- a/spiral_vector_db/__init__.py
+++ b/spiral_vector_db/__init__.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+"""Simple wrapper around ChromaDB for storing text embeddings."""
+
+from pathlib import Path
+from typing import Iterable, Any, Dict
+import os
+import uuid
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import chromadb
+    from chromadb.api import Collection
+except Exception:  # pragma: no cover - optional dependency
+    chromadb = None  # type: ignore
+    Collection = object  # type: ignore
+
+from MUSIC_FOUNDATION import qnl_utils
+
+_DEFAULT_PATH = Path(__file__).resolve().parents[1] / "data" / "spiral_vector_db"
+DB_PATH = Path(os.getenv("SPIRAL_VECTOR_PATH", str(_DEFAULT_PATH)))
+
+_COLLECTION_NAME = "spiral_vectors"
+_COLLECTION: Collection | None = None
+
+
+def init_db(path: Path | None = None) -> Collection:
+    """Return a persistent Chroma collection stored under ``path``."""
+    if chromadb is None:  # pragma: no cover - optional dependency
+        raise RuntimeError("chromadb library not installed")
+    global _COLLECTION, DB_PATH
+    if path is not None:
+        DB_PATH = path
+    if _COLLECTION is None:
+        DB_PATH.mkdir(parents=True, exist_ok=True)
+        client = chromadb.PersistentClient(path=str(DB_PATH))
+        _COLLECTION = client.get_or_create_collection(_COLLECTION_NAME)
+    return _COLLECTION
+
+
+def _get_collection() -> Collection:
+    if _COLLECTION is None:
+        return init_db()
+    return _COLLECTION
+
+
+def insert_embeddings(data: Iterable[dict]) -> None:
+    """Add ``data`` items with precomputed embeddings to the database."""
+    items = list(data)
+    if not items:
+        return
+    col = _get_collection()
+    ids = []
+    embeddings = []
+    metadatas = []
+    for item in items:
+        ids.append(item.get("id", uuid.uuid4().hex))
+        emb = item.get("embedding")
+        if emb is None:
+            emb = qnl_utils.quantum_embed(item.get("text", ""))
+        emb = np.asarray(emb, dtype=float).tolist()
+        embeddings.append(emb)
+        meta = {k: v for k, v in item.items() if k not in {"embedding", "id"}}
+        metadatas.append(meta)
+    col.add(ids=ids, embeddings=embeddings, metadatas=metadatas)
+
+
+def query_embeddings(text: str, top_k: int = 5, filters: dict | None = None) -> list[dict]:
+    """Return ``top_k`` matches for ``text`` ordered by cosine similarity."""
+    qvec = np.asarray(qnl_utils.quantum_embed(text), dtype=float)
+    col = _get_collection()
+    res = col.query(query_embeddings=[qvec.tolist()], n_results=max(top_k * 5, top_k))
+    metas = res.get("metadatas", [[]])[0]
+    embs = [np.asarray(e, dtype=float) for e in res.get("embeddings", [[]])[0]]
+
+    results: list[dict] = []
+    for emb, meta in zip(embs, metas):
+        if filters is not None:
+            skip = False
+            for key, val in filters.items():
+                if meta.get(key) != val:
+                    skip = True
+                    break
+            if skip:
+                continue
+        if getattr(emb, "size", len(emb)) == 0:
+            continue
+        dot = sum(float(a) * float(b) for a, b in zip(emb, qvec))
+        sim = float(dot / ((np.linalg.norm(emb) * np.linalg.norm(qvec)) + 1e-8))
+        rec = dict(meta)
+        rec["score"] = sim
+        results.append(rec)
+    results.sort(key=lambda m: m.get("score", 0.0), reverse=True)
+    return results[:top_k]
+
+
+__all__ = ["init_db", "insert_embeddings", "query_embeddings", "DB_PATH"]

--- a/tests/test_spiral_vector_db.py
+++ b/tests/test_spiral_vector_db.py
@@ -1,0 +1,98 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+import importlib
+
+# provide minimal numpy stub
+dummy_np = ModuleType("numpy")
+
+class NPArray(list):
+    def tolist(self):
+        return list(self)
+
+def _arr(x, dtype=None):
+    return NPArray(x)
+
+dummy_np.array = _arr
+
+def _asarray(x, dtype=None):
+    return NPArray(x)
+
+dummy_np.asarray = _asarray
+
+def _argsort(arr):
+    return sorted(range(len(arr)), key=lambda i: arr[i])
+
+dummy_np.argsort = _argsort
+
+def _norm(v):
+    return sum(i * i for i in v) ** 0.5
+
+dummy_np.linalg = SimpleNamespace(norm=_norm)
+sys.modules.setdefault("numpy", dummy_np)
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("MUSIC_FOUNDATION", ModuleType("MUSIC_FOUNDATION"))
+qlm_mod = ModuleType("qnl_utils")
+qlm_mod.quantum_embed = lambda t: np.array([0.0])
+sys.modules.setdefault("MUSIC_FOUNDATION.qnl_utils", qlm_mod)
+
+
+def test_insert_and_query(tmp_path, monkeypatch):
+    monkeypatch.setenv("SPIRAL_VECTOR_PATH", str(tmp_path / "db"))
+    if "spiral_vector_db" in sys.modules:
+        del sys.modules["spiral_vector_db"]
+    svdb = importlib.import_module("spiral_vector_db")
+
+    class DummyCollection:
+        def __init__(self):
+            self.records = []
+
+        def add(self, ids, embeddings, metadatas):
+            for e, m in zip(embeddings, metadatas):
+                self.records.append((np.asarray(e), m))
+
+        def query(self, query_embeddings, n_results, **_):
+            q = np.asarray(query_embeddings[0])
+            sims = [
+                sum(a * b for a, b in zip(e, q)) /
+                ((_norm(e) * _norm(q)) + 1e-8)
+                for e, _ in self.records
+            ]
+            order = list(reversed(sorted(range(len(sims)), key=lambda i: sims[i])))[:n_results]
+            return {
+                "embeddings": [[self.records[i][0] for i in order]],
+                "metadatas": [[self.records[i][1] for i in order]],
+            }
+
+    class DummyClient:
+        def __init__(self, path):
+            self.col = DummyCollection()
+
+        def get_or_create_collection(self, name):
+            return self.col
+
+    dummy_chroma = SimpleNamespace(PersistentClient=lambda path: DummyClient(path))
+    monkeypatch.setattr(svdb, "chromadb", dummy_chroma)
+    monkeypatch.setattr(
+        svdb.qnl_utils,
+        "quantum_embed",
+        lambda text: np.array([1.0, 0.0]) if "foo" in text else np.array([0.0, 1.0]),
+    )
+
+    svdb.init_db()
+    assert (tmp_path / "db").exists()
+
+    data = [
+        {"id": "a", "embedding": [1.0, 0.0], "label": "foo"},
+        {"id": "b", "embedding": [0.0, 1.0], "label": "bar"},
+    ]
+    svdb.insert_embeddings(data)
+
+    res = svdb.query_embeddings("foo text", top_k=1, filters={"label": "foo"})
+    assert len(res) == 1
+    assert res[0]["label"] == "foo"


### PR DESCRIPTION
## Summary
- create `spiral_vector_db` package with ChromaDB helpers
- add insert and query utilities
- default path from `SPIRAL_VECTOR_PATH`
- test insertion and querying using dummy implementations

## Testing
- `pytest tests/test_spiral_vector_db.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687932da86bc832ea2203fa9dd22767f