### PR TITLE
Add crown query routing and retriever

### DIFF
--- a/crown_query_router.py
+++ b/crown_query_router.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Route questions to the appropriate vector collection."""
+
+from typing import List, Dict
+
+import rag_retriever
+
+_STORE_MAP = {
+    "sage": "tech",
+    "hero": "tech",
+    "warrior": "ritual",
+    "orphan": "ritual",
+    "caregiver": "ritual",
+    "citrinitas": "ritual",
+    "jester": "music",
+    "everyman": "music",
+}
+
+
+def _select_store(archetype: str) -> str:
+    return _STORE_MAP.get(archetype.lower(), "tech")
+
+
+def route_query(question: str, archetype: str) -> List[Dict]:
+    """Return results for ``question`` using the store chosen by ``archetype``."""
+    store = _select_store(archetype)
+    return rag_retriever.retrieve_top(question, collection=store)
+
+
+__all__ = ["route_query"]

--- a/rag_retriever.py
+++ b/rag_retriever.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Query Chroma collections using a shared embedding model."""
+
+from pathlib import Path
+from typing import List, Dict, Any
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import chromadb
+    from chromadb.api import Collection
+except Exception:  # pragma: no cover - optional dependency
+    chromadb = None  # type: ignore
+    Collection = object  # type: ignore
+
+import rag_embedder
+
+_DB_DIR = Path("data") / "crown_queries"
+_COLLECTION_CACHE: dict[str, Collection] = {}
+
+
+def get_collection(name: str) -> Collection:
+    """Return Chroma collection ``name`` stored under :data:`_DB_DIR`."""
+    if chromadb is None:  # pragma: no cover - optional dependency
+        raise RuntimeError("chromadb library not installed")
+    col = _COLLECTION_CACHE.get(name)
+    if col is None:
+        _DB_DIR.mkdir(parents=True, exist_ok=True)
+        client = chromadb.PersistentClient(path=str(_DB_DIR))
+        col = client.get_or_create_collection(name)
+        _COLLECTION_CACHE[name] = col
+    return col
+
+
+def retrieve_top(question: str, top_n: int = 5, *, collection: str = "tech") -> List[Dict[str, Any]]:
+    """Return ranked snippets for ``question`` from ``collection``."""
+    model = rag_embedder._get_model()
+    query_emb = np.asarray(model.encode([question])[0], dtype=float)
+    col = get_collection(collection)
+    res = col.query(query_embeddings=[query_emb.tolist()], n_results=max(top_n * 5, top_n))
+    metas = res.get("metadatas", [[]])[0]
+    embs = [np.asarray(e, dtype=float) for e in res.get("embeddings", [[]])[0]]
+    results: list[Dict[str, Any]] = []
+    for emb, meta in zip(embs, metas):
+        if getattr(emb, "size", len(emb)) == 0:
+            continue
+        sim = float(emb @ query_emb / ((np.linalg.norm(emb) * np.linalg.norm(query_emb)) + 1e-8))
+        rec = dict(meta)
+        rec["score"] = sim
+        results.append(rec)
+    results.sort(key=lambda m: m.get("score", 0.0), reverse=True)
+    return results[:top_n]
+
+
+__all__ = ["retrieve_top", "get_collection"]

--- a/tests/test_crown_query_router.py
+++ b/tests/test_crown_query_router.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import types
+
+dummy_np = types.ModuleType("numpy")
+
+class NPArray(list):
+    def tolist(self):
+        return list(self)
+
+def _arr(x, dtype=None):
+    return NPArray(x)
+
+dummy_np.array = _arr
+dummy_np.asarray = _arr
+dummy_np.linalg = types.SimpleNamespace(norm=lambda v: sum(i * i for i in v) ** 0.5)
+sys.modules.setdefault("numpy", dummy_np)
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+
+import crown_query_router as cqr
+import rag_retriever
+
+
+def test_route_query_selects_store(monkeypatch):
+    called = {}
+    def fake_retrieve(q, top_n=5, collection="tech"):
+        called["store"] = collection
+        return []
+
+    monkeypatch.setattr(rag_retriever, "retrieve_top", fake_retrieve)
+
+    cqr.route_query("what is quantum code?", "Sage")
+    assert called["store"] == "tech"
+
+    cqr.route_query("sing a song", "Jester")
+    assert called["store"] == "music"

--- a/tests/test_rag_retriever.py
+++ b/tests/test_rag_retriever.py
@@ -1,0 +1,62 @@
+import sys
+from pathlib import Path
+import types
+
+dummy_np = types.ModuleType("numpy")
+
+class NPArray(list):
+    def tolist(self):
+        return list(self)
+
+    def __matmul__(self, other):
+        return sum(a * b for a, b in zip(self, other))
+
+def _arr(x, dtype=None):
+    return NPArray(x)
+
+dummy_np.array = _arr
+dummy_np.asarray = _arr
+dummy_np.linalg = types.SimpleNamespace(norm=lambda v: sum(i * i for i in v) ** 0.5)
+sys.modules.setdefault("numpy", dummy_np)
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import rag_retriever
+
+
+class DummyModel:
+    def encode(self, texts):
+        if isinstance(texts, str):
+            texts = [texts]
+        return [[1.0, 0.0] if "foo" in t else [0.0, 1.0] for t in texts]
+
+
+class DummyCollection:
+    def __init__(self):
+        self.records = [
+            (np.array([1.0, 0.0]), {"snippet": "A"}),
+            (np.array([0.0, 1.0]), {"snippet": "B"}),
+        ]
+
+    def query(self, query_embeddings, n_results, **_):
+        q = np.asarray(query_embeddings[0])
+        sims = [float(e @ q / ((np.linalg.norm(e) * np.linalg.norm(q)) + 1e-8)) for e, _ in self.records]
+        order = list(reversed(sorted(range(len(sims)), key=lambda i: sims[i])))[:n_results]
+        return {
+            "embeddings": [[self.records[i][0] for i in order]],
+            "metadatas": [[self.records[i][1] for i in order]],
+        }
+
+
+def test_retrieve_top_ranks(monkeypatch):
+    monkeypatch.setattr(rag_retriever.rag_embedder, "_get_model", lambda: DummyModel())
+    monkeypatch.setattr(rag_retriever, "get_collection", lambda name: DummyCollection())
+
+    res = rag_retriever.retrieve_top("foo question", top_n=2, collection="tech")
+
+    assert [r["snippet"] for r in res] == ["A", "B"]
+    assert res[0]["score"] >= res[1]["score"]


### PR DESCRIPTION
## Summary
- implement `crown_query_router.route_query` for selecting a vector collection
- add `rag_retriever.retrieve_top` using shared embedder and Chroma
- test retrieval scoring and routing logic

## Testing
- `pytest -q tests/test_rag_retriever.py tests/test_crown_query_router.py`

------
https://chatgpt.com/codex/tasks/task_e_6879348474bc832ea3e1c5d6fe5f920a