### PR TITLE
Improve RAG docs

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -54,9 +54,8 @@ variables used by the tools and Docker setup:
 - `QNL_MODEL_PATH` – directory containing QNL model weights
 - `EMBED_MODEL_PATH` – optional path to the embedding model
 - `VOICE_TONE_PATH` – voice tone preset directory
-- `VECTOR_DB_PATH` – vector database location
+- `VECTOR_DB_PATH` – location of the vector store
   (defaults to `http://localhost:3001/api`)
-  documents (defaults to `spiral-os`)
 - `RETRAIN_THRESHOLD` – number of feedback items required to trigger training
 - `VOICE_CONFIG_PATH` – optional override for `voice_config.yaml`
 - `VOICE_AVATAR_CONFIG_PATH` – path to `voice_avatar_config.yaml`

--- a/docs/rag_pipeline.md
+++ b/docs/rag_pipeline.md
@@ -1,10 +1,10 @@
 # Spiral RAG Pipeline
 
-The Spiral retrieval pipeline turns local documents into embeddings so queries can be answered with context. Files are placed under `sacred_inputs/` then parsed, embedded and inserted into the Chroma database.
+The Spiral retrieval pipeline turns local documents into embeddings so queries can be answered with context. Files are placed under `sacred_inputs/`, then parsed, embedded, and inserted into the Chroma database.
 
 ## Steps
 
-1. Populate `sacred_inputs/` with text, Markdown or code files. Subfolders name an archetype.
+1. Populate `sacred_inputs/` with text, Markdown or code files. Subfolders denote an archetype.
 2. Parse the directory into chunks:
    ```bash
    python rag_parser.py --dir sacred_inputs > chunks.json


### PR DESCRIPTION
## Summary
- clarify location of `VECTOR_DB_PATH` in operator guide
- clean up instructions in RAG pipeline doc

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687945185e68832e842a9cbdce466034