### PR TITLE
Add OS Guardian package with CLI

### DIFF
--- a/os_guardian/__init__.py
+++ b/os_guardian/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for operating system automation."""
+
+from . import action_engine, perception, planning, cli
+
+__all__ = ["action_engine", "perception", "planning", "cli"]

--- a/os_guardian/action_engine.py
+++ b/os_guardian/action_engine.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Wrappers around OS input automation and browser control."""
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    import pyautogui  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    pyautogui = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from selenium import webdriver  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    webdriver = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def open_app(path: str | Path) -> subprocess.Popen[str] | None:
+    """Launch an application at ``path``."""
+    try:
+        return subprocess.Popen([str(path)])
+    except OSError as exc:  # pragma: no cover - OS dependent
+        logger.error("Failed to open %s: %s", path, exc)
+    return None
+
+
+def click(x: int, y: int) -> None:
+    """Send a mouse click to ``(x, y)``."""
+    if pyautogui is None:
+        logger.error("pyautogui not installed")
+        return
+    pyautogui.click(x=x, y=y)
+
+
+def type_text(text: str) -> None:
+    """Type ``text`` using the system keyboard."""
+    if pyautogui is None:
+        logger.error("pyautogui not installed")
+        return
+    pyautogui.typewrite(text)
+
+
+def open_url(
+    url: str, driver: Optional["webdriver.WebDriver"] = None
+) -> Optional["webdriver.WebDriver"]:
+    """Open ``url`` using Selenium."""
+    if webdriver is None:
+        logger.error("selenium not installed")
+        return None
+    drv = driver or webdriver.Firefox()
+    drv.get(url)
+    return drv
+
+
+__all__ = ["open_app", "click", "type_text", "open_url"]

--- a/os_guardian/cli.py
+++ b/os_guardian/cli.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Command line interface for OS Guardian."""
+
+import argparse
+
+from . import action_engine, planning
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the ``os_guardian`` CLI."""
+    parser = argparse.ArgumentParser(prog="os-guardian")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    open_p = sub.add_parser("open_app", help="Launch an application")
+    open_p.add_argument("path")
+
+    click_p = sub.add_parser("click", help="Click coordinates")
+    click_p.add_argument("x", type=int)
+    click_p.add_argument("y", type=int)
+
+    type_p = sub.add_parser("type", help="Type text")
+    type_p.add_argument("text")
+
+    plan_p = sub.add_parser("plan", help="Plan a command")
+    plan_p.add_argument("command")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "open_app":
+        action_engine.open_app(args.path)
+    elif args.cmd == "click":
+        action_engine.click(args.x, args.y)
+    elif args.cmd == "type":
+        action_engine.type_text(args.text)
+    elif args.cmd == "plan":
+        steps = planning.plan(args.command)
+        for step in steps:
+            print(step)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/os_guardian/perception.py
+++ b/os_guardian/perception.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Screen capture and GUI detection utilities."""
+
+import logging
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    cv2 = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from ultralytics import YOLO  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    YOLO = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import pytesseract  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    pytesseract = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import pyautogui  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    pyautogui = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import numpy as np
+except Exception:  # pragma: no cover - optional dependency
+    np = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def capture_screen(
+    region: Tuple[int, int, int, int] | None = None,
+) -> Optional["np.ndarray"]:
+    """Return a screenshot as an RGB array."""
+    if pyautogui is None or cv2 is None or np is None:
+        logger.warning("Screen capture requires pyautogui and opencv-python")
+        return None
+    image = pyautogui.screenshot(region=region)
+    frame = cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR)
+    return frame
+
+
+def detect_gui_elements(
+    image: "np.ndarray", model_path: str | Path | None = None
+) -> List[Tuple[str, float, Tuple[int, int, int, int]]]:
+    """Detect GUI elements in ``image`` using YOLOv8."""
+    if YOLO is None or cv2 is None:
+        logger.warning("YOLOv8 or OpenCV not available")
+        return []
+    model = YOLO(str(model_path) if model_path else "yolov8n.pt")
+    results = model(image)
+    detections: List[Tuple[str, float, Tuple[int, int, int, int]]] = []
+    names = getattr(model, "names", getattr(model, "model", None) and model.model.names)
+    for r in results:
+        for box in r.boxes:
+            cls_name = names[int(box.cls)] if names else str(int(box.cls))
+            conf = float(box.conf)
+            x1, y1, x2, y2 = box.xyxy[0].tolist()
+            detections.append((cls_name, conf, (int(x1), int(y1), int(x2), int(y2))))
+    return detections
+
+
+def extract_text(image: "np.ndarray") -> str:
+    """Return text found in ``image`` using Tesseract OCR."""
+    if pytesseract is None:
+        logger.warning("pytesseract not installed")
+        return ""
+    return pytesseract.image_to_string(image)
+
+
+__all__ = ["capture_screen", "detect_gui_elements", "extract_text"]

--- a/os_guardian/planning.py
+++ b/os_guardian/planning.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""LangChain-based planner for converting instructions into action plans."""
+
+import logging
+from typing import List
+
+from langchain.chains import LLMChain
+from langchain.chat_models import ChatOpenAI
+from langchain.prompts import PromptTemplate
+
+logger = logging.getLogger(__name__)
+
+_PROMPT = PromptTemplate(
+    input_variables=["command"],
+    template="Generate a numbered list of steps to accomplish: {command}",
+)
+
+
+def plan(command: str) -> List[str]:
+    """Return a list of action steps for ``command``."""
+    llm = ChatOpenAI(temperature=0)
+    chain = LLMChain(llm=llm, prompt=_PROMPT)
+    result = chain.predict(command=command)
+    return [line.strip("- ") for line in result.splitlines() if line.strip()]
+
+
+__all__ = ["plan"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,12 @@ dependencies = [
     "aiortc",
     "wav2lip",
     "psutil",
+    "pyautogui",
+    "opencv-python",
+    "pytesseract",
+    "selenium",
+    "ultralytics",
+    "langchain",
 ]
 
 [project.optional-dependencies]
@@ -68,6 +74,9 @@ dev = [
     "pre-commit",
     "psutil",
 ]
+
+[project.scripts]
+os-guardian = "os_guardian.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- add `os_guardian` package for automation helpers
- implement perception, action engine, and planning modules
- add CLI entrypoint `os_guardian.cli:main`
- configure dependencies and script in `pyproject.toml`

## Testing
- `python -m py_compile os_guardian/*.py`
- `black --check os_guardian`
- `pytest -k os_guardian -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687949b0fdc8832eb72875c1bed4f2ff