### PR TITLE
Add OS Guardian Docker support

### DIFF
--- a/docker/os_guardian.Dockerfile
+++ b/docker/os_guardian.Dockerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1
+FROM python:3.10-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /workspace
+
+COPY requirements.txt .
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ffmpeg \
+        tesseract-ocr \
+        libgl1 \
+        libglib2.0-0 \
+        libsm6 \
+        libxext6 \
+        libxrender1 \
+        libgtk-3-0 \
+        libnss3 \
+        libxrandr2 \
+        libasound2 \
+        libxi6 \
+        scrot \
+        x11-apps \
+        firefox-esr \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip wheel --no-cache-dir --wheel-dir /wheels -r requirements.txt
+
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ffmpeg \
+        tesseract-ocr \
+        libgl1 \
+        libglib2.0-0 \
+        libsm6 \
+        libxext6 \
+        libxrender1 \
+        libgtk-3-0 \
+        libnss3 \
+        libxrandr2 \
+        libasound2 \
+        libxi6 \
+        scrot \
+        x11-apps \
+        firefox-esr \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+COPY --from=builder /wheels /wheels
+RUN pip install --no-cache-dir --no-index --find-links=/wheels /wheels/* && rm -rf /wheels
+
+COPY . .
+
+ENTRYPOINT ["os-guardian"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ The `docs` directory contains reference material for Spiral OS.
 - [avatar_ethics.md](avatar_ethics.md)
 - [avatar_pipeline.md](avatar_pipeline.md)
 - [cloud_deployment.md](cloud_deployment.md)
+- [os_guardian_container.md](os_guardian_container.md)
 - [crown_manifest.md](crown_manifest.md)
 - [deployment_overview.md](deployment_overview.md)
 - [design.md](design.md)

--- a/docs/os_guardian_container.md
+++ b/docs/os_guardian_container.md
@@ -1,0 +1,38 @@
+# OS Guardian Container
+
+This guide covers running the `os_guardian` tools inside Docker.
+
+## Environment variables
+
+Set the following variables to configure the container:
+
+- `DISPLAY` – display server address for GUI automation (e.g. `:0`).
+- `YOLO_MODEL_PATH` – optional path to YOLOv8 weights for screen detection.
+- `TESSDATA_PREFIX` – directory containing Tesseract language data.
+- `HF_HOME` – optional location for cached Hugging Face models.
+
+Variables from `secrets.env` are also loaded by the helper script.
+
+## Build and launch
+
+Use the provided script to build the image and start the container:
+
+```bash
+bash scripts/setup_os_guardian.sh
+```
+
+The script mounts the repository at `/workspace`, forwards the host display using
+`/tmp/.X11-unix` and publishes port `8000` for optional services. Additional
+arguments are passed directly to `os-guardian` inside the container.
+
+To run manually without the script:
+
+```bash
+docker build -f docker/os_guardian.Dockerfile -t os_guardian .
+docker run -it --rm \
+  -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -v "$(pwd)":/workspace \
+  -p 8000:8000 \
+  os_guardian
+```

--- a/scripts/setup_os_guardian.sh
+++ b/scripts/setup_os_guardian.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Build and run the OS Guardian container
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load environment variables if secrets.env exists
+if [ -f "$REPO_ROOT/secrets.env" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/secrets.env"
+    set +a
+fi
+
+cd "$REPO_ROOT"
+
+docker build -f docker/os_guardian.Dockerfile -t os_guardian .
+
+docker run -it --rm \
+    -e DISPLAY="${DISPLAY:-:0}" \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -v "$REPO_ROOT":/workspace \
+    -p 8000:8000 \
+    os_guardian "$@"


### PR DESCRIPTION
## Summary
- provide Dockerfile for OS Guardian
- add helper script to build and run the container
- document environment variables and usage
- link new doc in the docs index

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68794b257c44832e886c6bfaf21ede06