### PR TITLE
Implement OS action helpers with tests

### DIFF
--- a/os_guardian/action_engine.py
+++ b/os_guardian/action_engine.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 """Wrappers around OS input automation and browser control."""
 
 import logging
+import shlex
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 
 try:  # pragma: no cover - optional dependency
     import pyautogui  # type: ignore
@@ -18,6 +19,9 @@ except Exception:  # pragma: no cover - optional dependency
     webdriver = None  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+# Basic allowlist of commands permitted for :func:`run_command`.
+SAFE_COMMANDS = {"echo", "ls", "pwd", "cat"}
 
 
 def open_app(path: str | Path) -> subprocess.Popen[str] | None:
@@ -37,12 +41,40 @@ def click(x: int, y: int) -> None:
     pyautogui.click(x=x, y=y)
 
 
+def scroll(amount: int) -> None:
+    """Scroll vertically by ``amount`` pixels."""
+    if pyautogui is None:
+        logger.error("pyautogui not installed")
+        return
+    pyautogui.scroll(amount)
+
+
 def type_text(text: str) -> None:
     """Type ``text`` using the system keyboard."""
     if pyautogui is None:
         logger.error("pyautogui not installed")
         return
     pyautogui.typewrite(text)
+
+
+def run_command(cmd: str | Sequence[str]) -> subprocess.CompletedProcess[str] | None:
+    """Run a shell command from an allowlist."""
+    if isinstance(cmd, str):
+        args = shlex.split(cmd)
+    else:
+        args = list(cmd)
+    if not args:
+        logger.error("Empty command")
+        return None
+    binary = Path(args[0]).name
+    if binary not in SAFE_COMMANDS:
+        logger.error("Command %s not allowed", binary)
+        return None
+    try:
+        return subprocess.run(args, capture_output=True, text=True, check=False)
+    except OSError as exc:  # pragma: no cover - OS dependent
+        logger.error("Failed to run %s: %s", binary, exc)
+        return None
 
 
 def open_url(
@@ -57,4 +89,24 @@ def open_url(
     return drv
 
 
-__all__ = ["open_app", "click", "type_text", "open_url"]
+def run_js(script: str, driver: "webdriver.WebDriver") -> Optional[object]:
+    """Execute JavaScript ``script`` in ``driver``."""
+    if webdriver is None:
+        logger.error("selenium not installed")
+        return None
+    try:
+        return driver.execute_script(script)
+    except Exception as exc:  # pragma: no cover - browser dependent
+        logger.error("Failed to run script: %s", exc)
+    return None
+
+
+__all__ = [
+    "open_app",
+    "click",
+    "type_text",
+    "scroll",
+    "run_command",
+    "open_url",
+    "run_js",
+]

--- a/tests/test_os_guardian_action_engine.py
+++ b/tests/test_os_guardian_action_engine.py
@@ -1,0 +1,83 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Create dummy pyautogui module
+calls = {}
+
+def _record(name, value):
+    calls.setdefault(name, []).append(value)
+
+pyautogui = types.ModuleType("pyautogui")
+pyautogui.click = lambda x=0, y=0: _record("click", (x, y))
+pyautogui.typewrite = lambda text: _record("typewrite", text)
+pyautogui.scroll = lambda amount: _record("scroll", amount)
+sys.modules["pyautogui"] = pyautogui
+
+# Create dummy selenium webdriver module
+class DummyDriver:
+    def get(self, url):
+        _record("get", url)
+
+    def execute_script(self, script):
+        _record("js", script)
+        return "result"
+
+webdriver = types.SimpleNamespace(Firefox=lambda: DummyDriver())
+selenium = types.ModuleType("selenium")
+selenium.webdriver = webdriver
+sys.modules["selenium"] = selenium
+sys.modules["selenium.webdriver"] = webdriver
+
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "action_engine", ROOT / "os_guardian" / "action_engine.py"
+)
+action_engine = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = action_engine
+assert spec.loader is not None
+spec.loader.exec_module(action_engine)
+
+
+def test_mouse_and_keyboard_actions():
+    calls.clear()
+    action_engine.click(1, 2)
+    action_engine.type_text("hi")
+    action_engine.scroll(-5)
+    assert calls["click"] == [(1, 2)]
+    assert calls["typewrite"] == ["hi"]
+    assert calls["scroll"] == [-5]
+
+
+def test_run_command_whitelist(monkeypatch):
+    recorded = []
+
+    def fake_run(args, capture_output=True, text=True, check=False):
+        recorded.append(list(args))
+        class CP:
+            def __init__(self):
+                self.args = args
+                self.stdout = "ok"
+        return CP()
+
+    monkeypatch.setattr(action_engine.subprocess, "run", fake_run)
+    res = action_engine.run_command(["echo", "hello"])
+    assert recorded == [["echo", "hello"]]
+    assert res.stdout == "ok"
+    res = action_engine.run_command("rm -rf /")
+    assert res is None
+    assert recorded == [["echo", "hello"]]
+
+
+def test_open_url_and_js():
+    calls.clear()
+    drv = action_engine.open_url("http://example.com")
+    assert isinstance(drv, DummyDriver)
+    assert calls["get"] == ["http://example.com"]
+    out = action_engine.run_js("return 1;", drv)
+    assert out == "result"
+    assert calls["js"] == ["return 1;"]


### PR DESCRIPTION
## Summary
- extend `action_engine` with scroll, safe shell commands, and JS helpers
- add run command safety checks
- create unit tests for action engine behavior

## Testing
- `pytest -q tests/test_os_guardian_action_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68794def12b8832e9c0f08c405726ff1