### PR TITLE
Implement GuardianPlanner using LangChain

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ The `docs` directory contains reference material for Spiral OS.
 - [avatar_pipeline.md](avatar_pipeline.md)
 - [cloud_deployment.md](cloud_deployment.md)
 - [os_guardian_container.md](os_guardian_container.md)
+- [os_guardian_planning.md](os_guardian_planning.md)
 - [crown_manifest.md](crown_manifest.md)
 - [deployment_overview.md](deployment_overview.md)
 - [design.md](design.md)

--- a/docs/os_guardian_planning.md
+++ b/docs/os_guardian_planning.md
@@ -1,0 +1,22 @@
+# OS Guardian Planning
+
+The planning module converts natural language instructions into a sequence of
+calls to the perception and action components. It stores previous plans in a
+vector memory so repeated requests share context.
+
+## Examples
+
+```python
+from os_guardian.planning import GuardianPlanner
+
+planner = GuardianPlanner()
+steps = planner.plan("Open the browser and search for Spiral OS")
+for step in steps:
+    print(step)
+
+# Incorporate perception feedback
+steps = planner.interactive_plan(
+    "Click the highlighted result",
+    perception_feedback="Found a button labelled 'Spiral OS'"
+)
+```

--- a/os_guardian/planning.py
+++ b/os_guardian/planning.py
@@ -1,28 +1,142 @@
 from __future__ import annotations
 
-"""LangChain-based planner for converting instructions into action plans."""
+"""LangChain-based planner turning instructions into tool sequences.
 
+The planner exposes :class:`GuardianPlanner` which builds a small LangChain agent
+using the perception and action modules as tools. Generated plans are stored in a
+vector store so future instructions may reference past context.
+"""
+
+from dataclasses import dataclass
 import logging
-from typing import List
+from pathlib import Path
+from typing import List, Sequence
 
-from langchain.chains import LLMChain
-from langchain.chat_models import ChatOpenAI
-from langchain.prompts import PromptTemplate
+try:  # pragma: no cover - optional dependency
+    from langchain.agents import AgentType, Tool, initialize_agent
+    from langchain.chat_models import ChatOpenAI
+    from langchain.embeddings import HuggingFaceEmbeddings
+    from langchain.memory import VectorStoreRetrieverMemory
+    from langchain.schema import Document
+    from langchain.vectorstores import FAISS
+except Exception:  # pragma: no cover - optional dependency
+    AgentType = Tool = initialize_agent = None  # type: ignore
+    ChatOpenAI = None  # type: ignore
+    HuggingFaceEmbeddings = None  # type: ignore
+    VectorStoreRetrieverMemory = None  # type: ignore
+    Document = None  # type: ignore
+    FAISS = None  # type: ignore
+
+from . import action_engine, perception
 
 logger = logging.getLogger(__name__)
 
-_PROMPT = PromptTemplate(
-    input_variables=["command"],
-    template="Generate a numbered list of steps to accomplish: {command}",
-)
+_MEMORY_DIR = Path("data/os_guardian_memory")
+
+
+def _load_memory(path: Path = _MEMORY_DIR) -> VectorStoreRetrieverMemory | None:
+    """Return a vector memory instance stored at ``path`` if possible."""
+    if FAISS is None or HuggingFaceEmbeddings is None or VectorStoreRetrieverMemory is None:
+        return None
+    path.mkdir(parents=True, exist_ok=True)
+    emb = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+    index = path / "faiss"
+    if index.exists():
+        store = FAISS.load_local(str(index), emb)
+    else:
+        store = FAISS.from_texts([], emb)
+        store.save_local(str(index))
+    retriever = store.as_retriever(search_kwargs={"k": 4})
+    return VectorStoreRetrieverMemory(retriever=retriever)
+
+
+def _get_tools() -> Sequence[Tool]:
+    if Tool is None:
+        return []
+    return [
+        Tool.from_function(
+            name="analyze_frame",
+            func=perception.analyze_frame,
+            description="Analyze a screen capture for UI elements",
+        ),
+        Tool.from_function(
+            name="click",
+            func=action_engine.click,
+            description="Click on screen coordinates",
+        ),
+        Tool.from_function(
+            name="type_text",
+            func=action_engine.type_text,
+            description="Type text with the keyboard",
+        ),
+        Tool.from_function(
+            name="open_url",
+            func=action_engine.open_url,
+            description="Open a URL in the browser",
+        ),
+    ]
+
+
+@dataclass
+class GuardianPlanner:
+    """LangChain agent wrapper for OS Guardian planning."""
+
+    memory_path: Path = _MEMORY_DIR
+    llm: ChatOpenAI | None = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - init
+        if self.llm is None and ChatOpenAI is not None:
+            self.llm = ChatOpenAI(temperature=0)
+        self.memory = _load_memory(self.memory_path)
+
+    # Internal -----------------------------------------------------------------
+    def _build_agent(self):
+        if initialize_agent is None or self.llm is None:
+            return None
+        return initialize_agent(
+            tools=_get_tools(),
+            llm=self.llm,
+            agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+            memory=self.memory,
+            verbose=False,
+        )
+
+    # Public API ---------------------------------------------------------------
+    def plan(self, instruction: str) -> List[str]:
+        """Generate an ordered list of tool invocations for ``instruction``."""
+        agent = self._build_agent()
+        if agent is None:
+            logger.error("LangChain not available")
+            return []
+        result = agent.run(instruction)
+        if self.memory is not None:
+            self.memory.save_context({"instruction": instruction}, {"plan": result})
+        return [
+            line.lstrip("0123456789. -").strip()
+            for line in result.splitlines()
+            if line.strip()
+        ]
+
+    def interactive_plan(self, instruction: str, perception_feedback: str) -> List[str]:
+        """Adjust a plan using additional perception feedback."""
+        agent = self._build_agent()
+        if agent is None:
+            logger.error("LangChain not available")
+            return []
+        query = f"{instruction}\nFeedback: {perception_feedback}"
+        result = agent.run(query)
+        if self.memory is not None:
+            self.memory.save_context({"instruction": query}, {"plan": result})
+        return [
+            line.lstrip("0123456789. -").strip()
+            for line in result.splitlines()
+            if line.strip()
+        ]
 
 
 def plan(command: str) -> List[str]:
-    """Return a list of action steps for ``command``."""
-    llm = ChatOpenAI(temperature=0)
-    chain = LLMChain(llm=llm, prompt=_PROMPT)
-    result = chain.predict(command=command)
-    return [line.strip("- ") for line in result.splitlines() if line.strip()]
+    """Convenience wrapper returning plan steps for ``command``."""
+    return GuardianPlanner().plan(command)
 
 
-__all__ = ["plan"]
+__all__ = ["plan", "GuardianPlanner"]

--- a/tests/test_os_guardian_planning.py
+++ b/tests/test_os_guardian_planning.py
@@ -1,0 +1,82 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub langchain modules used by planning
+class DummyAgent:
+    def __init__(self):
+        self.calls = []
+
+    def run(self, text):
+        self.calls.append(text)
+        if "Feedback" in text:
+            return "1. click(10,10)\n2. done"
+        return "1. analyze_frame()\n2. type_text('hi')"
+
+def dummy_initialize_agent(*a, **k):
+    return DummyAgent()
+
+langchain = types.ModuleType("langchain")
+agents_mod = types.ModuleType("langchain.agents")
+agents_mod.initialize_agent = dummy_initialize_agent
+agents_mod.AgentType = types.SimpleNamespace(ZERO_SHOT_REACT_DESCRIPTION="desc")
+
+class DummyTool:
+    @classmethod
+    def from_function(cls, *, name=None, func=None, description=None):
+        return {"name": name, "func": func, "description": description}
+
+agents_mod.Tool = DummyTool
+chat_mod = types.ModuleType("langchain.chat_models")
+chat_mod.ChatOpenAI = lambda *a, **k: object()
+embeddings_mod = types.ModuleType("langchain.embeddings")
+class DummyEmb:
+    def __init__(self, *a, **k):
+        pass
+embeddings_mod.HuggingFaceEmbeddings = DummyEmb
+vector_mod = types.ModuleType("langchain.vectorstores")
+vector_mod.FAISS = types.SimpleNamespace(
+    from_texts=lambda texts, embed: types.SimpleNamespace(
+        as_retriever=lambda **k: None, save_local=lambda *a: None
+    ),
+    load_local=lambda path, embed: types.SimpleNamespace(
+        as_retriever=lambda **k: None, save_local=lambda *a: None
+    ),
+)
+memory_mod = types.ModuleType("langchain.memory")
+class DummyMemory:
+    def __init__(self, retriever=None):
+        self.saved = []
+    def save_context(self, inp, out):
+        self.saved.append((inp, out))
+    def load_memory_variables(self, inp):
+        return {"history": ""}
+memory_mod.VectorStoreRetrieverMemory = lambda retriever=None: DummyMemory()
+
+schema_mod = types.ModuleType("langchain.schema")
+schema_mod.Document = object
+
+sys.modules.setdefault("langchain", langchain)
+sys.modules.setdefault("langchain.agents", agents_mod)
+sys.modules.setdefault("langchain.chat_models", chat_mod)
+sys.modules.setdefault("langchain.embeddings", embeddings_mod)
+sys.modules.setdefault("langchain.vectorstores", vector_mod)
+sys.modules.setdefault("langchain.memory", memory_mod)
+sys.modules.setdefault("langchain.schema", schema_mod)
+
+import importlib
+
+planning = importlib.import_module("os_guardian.planning")
+
+
+def test_plan_and_feedback(tmp_path):
+    planner = planning.GuardianPlanner(memory_path=tmp_path)
+    steps = planner.plan("demo instruction")
+    assert steps == ["analyze_frame()", "type_text('hi')"]
+
+    steps2 = planner.interactive_plan("next", "button")
+    assert steps2 and steps2[0].startswith("click")
+    assert planner.memory is not None


### PR DESCRIPTION
## Summary
- add GuardianPlanner in `os_guardian.planning` using LangChain tools
- store plan context in FAISS-based vector memory
- document how to generate plans with examples
- index planning doc in documentation
- test plan generation with stubbed LangChain modules

## Testing
- `pytest tests/test_os_guardian_planning.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687950990b30832eadd575dcfa4135d9