### PR TITLE
Introduce safety checks to OS Guardian

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ The `docs` directory contains reference material for Spiral OS.
 - [cloud_deployment.md](cloud_deployment.md)
 - [os_guardian_container.md](os_guardian_container.md)
 - [os_guardian_planning.md](os_guardian_planning.md)
+- [os_guardian_permissions.md](os_guardian_permissions.md)
 - [crown_manifest.md](crown_manifest.md)
 - [deployment_overview.md](deployment_overview.md)
 - [design.md](design.md)

--- a/docs/os_guardian_container.md
+++ b/docs/os_guardian_container.md
@@ -10,6 +10,9 @@ Set the following variables to configure the container:
 - `YOLO_MODEL_PATH` – optional path to YOLOv8 weights for screen detection.
 - `TESSDATA_PREFIX` – directory containing Tesseract language data.
 - `HF_HOME` – optional location for cached Hugging Face models.
+- `OG_POLICY` – permission mode for high-risk actions (`allow`, `ask`, `deny`).
+- `OG_ALLOWED_APPS`, `OG_ALLOWED_DOMAINS`, `OG_ALLOWED_COMMANDS` – whitelists
+  for the safety module.
 
 Variables from `secrets.env` are also loaded by the helper script.
 

--- a/docs/os_guardian_permissions.md
+++ b/docs/os_guardian_permissions.md
@@ -1,0 +1,20 @@
+# OS Guardian Permission Policies
+
+The `safety` module guards high-risk actions executed by the OS Guardian
+utilities. Permissions are configured with environment variables so deployments
+can choose an appropriate security posture.
+
+## Variables
+
+- `OG_ALLOWED_APPS` – colon-separated list of executable names or paths that may
+  be launched with `open_app`.
+- `OG_ALLOWED_DOMAINS` – colon-separated list of domains that `open_url` is
+  permitted to access.
+- `OG_ALLOWED_COMMANDS` – colon-separated list of command names allowed via
+  `run_command`. Defaults to `echo`, `ls`, `pwd` and `cat` if unset.
+- `OG_POLICY` – behaviour when an action is requested that may have side
+  effects. Set to `allow` (default) to run automatically, `ask` to prompt for
+  confirmation or `deny` to block.
+
+Rollback handlers registered by `safety.register_undo()` can be triggered with
+`undo_last()` or `undo_all()` if reversible actions were performed.

--- a/os_guardian/action_engine.py
+++ b/os_guardian/action_engine.py
@@ -8,6 +8,8 @@ import subprocess
 from pathlib import Path
 from typing import Optional, Sequence
 
+from . import safety
+
 try:  # pragma: no cover - optional dependency
     import pyautogui  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
@@ -20,14 +22,15 @@ except Exception:  # pragma: no cover - optional dependency
 
 logger = logging.getLogger(__name__)
 
-# Basic allowlist of commands permitted for :func:`run_command`.
-SAFE_COMMANDS = {"echo", "ls", "pwd", "cat"}
-
 
 def open_app(path: str | Path) -> subprocess.Popen[str] | None:
-    """Launch an application at ``path``."""
+    """Launch an application at ``path`` after policy check."""
+    if not safety.app_allowed(path) or not safety.confirm(f"Open app {path}?"):
+        return None
     try:
-        return subprocess.Popen([str(path)])
+        proc = subprocess.Popen([str(path)])
+        safety.register_undo(lambda: proc.terminate())
+        return proc
     except OSError as exc:  # pragma: no cover - OS dependent
         logger.error("Failed to open %s: %s", path, exc)
     return None
@@ -38,6 +41,8 @@ def click(x: int, y: int) -> None:
     if pyautogui is None:
         logger.error("pyautogui not installed")
         return
+    if not safety.confirm(f"Click at {x},{y}?"):
+        return
     pyautogui.click(x=x, y=y)
 
 
@@ -46,6 +51,8 @@ def scroll(amount: int) -> None:
     if pyautogui is None:
         logger.error("pyautogui not installed")
         return
+    if not safety.confirm(f"Scroll {amount} pixels?"):
+        return
     pyautogui.scroll(amount)
 
 
@@ -53,6 +60,8 @@ def type_text(text: str) -> None:
     """Type ``text`` using the system keyboard."""
     if pyautogui is None:
         logger.error("pyautogui not installed")
+        return
+    if not safety.confirm(f"Type text: {text[:20]}..."):
         return
     pyautogui.typewrite(text)
 
@@ -67,11 +76,12 @@ def run_command(cmd: str | Sequence[str]) -> subprocess.CompletedProcess[str] | 
         logger.error("Empty command")
         return None
     binary = Path(args[0]).name
-    if binary not in SAFE_COMMANDS:
+    if not safety.command_allowed(binary) or not safety.confirm(f"Run {binary}?"):
         logger.error("Command %s not allowed", binary)
         return None
     try:
-        return subprocess.run(args, capture_output=True, text=True, check=False)
+        proc = subprocess.run(args, capture_output=True, text=True, check=False)
+        return proc
     except OSError as exc:  # pragma: no cover - OS dependent
         logger.error("Failed to run %s: %s", binary, exc)
         return None
@@ -84,8 +94,11 @@ def open_url(
     if webdriver is None:
         logger.error("selenium not installed")
         return None
+    if not safety.domain_allowed(url) or not safety.confirm(f"Open URL {url}?"):
+        return None
     drv = driver or webdriver.Firefox()
     drv.get(url)
+    safety.register_undo(lambda: getattr(drv, "quit", lambda: None)())
     return drv
 
 
@@ -93,6 +106,8 @@ def run_js(script: str, driver: "webdriver.WebDriver") -> Optional[object]:
     """Execute JavaScript ``script`` in ``driver``."""
     if webdriver is None:
         logger.error("selenium not installed")
+        return None
+    if not safety.confirm("Execute JavaScript?"):
         return None
     try:
         return driver.execute_script(script)

--- a/os_guardian/safety.py
+++ b/os_guardian/safety.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Permission checks and rollback helpers for OS Guardian actions."""
+
+import logging
+import os
+from pathlib import Path
+from typing import Callable, Iterable, List
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# Allowlist values may be populated via environment variables
+_DEFAULT_COMMANDS = {"echo", "ls", "pwd", "cat"}
+_ALLOWED_COMMANDS = set(filter(None, os.environ.get("OG_ALLOWED_COMMANDS", "").split(os.pathsep)))
+if not _ALLOWED_COMMANDS:
+    _ALLOWED_COMMANDS = set(_DEFAULT_COMMANDS)
+
+_ALLOWED_APPS = set(filter(None, os.environ.get("OG_ALLOWED_APPS", "").split(os.pathsep)))
+_ALLOWED_DOMAINS = set(filter(None, os.environ.get("OG_ALLOWED_DOMAINS", "").split(os.pathsep)))
+
+_POLICY = os.environ.get("OG_POLICY", "allow").lower()  # allow, ask or deny
+
+# Simple stack of undo callbacks
+_UNDO_STACK: List[Callable[[], None]] = []
+
+
+def command_allowed(cmd: str) -> bool:
+    """Return ``True`` if shell command ``cmd`` is permitted."""
+    return cmd in _ALLOWED_COMMANDS
+
+
+def app_allowed(path: str | Path) -> bool:
+    """Return ``True`` if application ``path`` is permitted."""
+    name = Path(path).name
+    return not _ALLOWED_APPS or name in _ALLOWED_APPS or str(path) in _ALLOWED_APPS
+
+
+def domain_allowed(url: str) -> bool:
+    """Return ``True`` if ``url`` is within an allowed domain."""
+    host = urlparse(url).hostname or ""
+    return not _ALLOWED_DOMAINS or host in _ALLOWED_DOMAINS
+
+
+def confirm(prompt: str) -> bool:
+    """Return ``True`` if the action should proceed based on ``_POLICY``."""
+    if _POLICY == "allow":
+        return True
+    if _POLICY == "deny":
+        logger.warning("Denied: %s", prompt)
+        return False
+    try:
+        answer = input(f"{prompt} [y/N]: ").strip().lower()
+    except EOFError:
+        return False
+    return answer in {"y", "yes"}
+
+
+def register_undo(func: Callable[[], None]) -> None:
+    """Register ``func`` to undo a completed action."""
+    _UNDO_STACK.append(func)
+
+
+def undo_last() -> None:
+    """Undo the most recent reversible action."""
+    if _UNDO_STACK:
+        undo = _UNDO_STACK.pop()
+        try:
+            undo()
+        except Exception as exc:  # pragma: no cover - undo failure is best effort
+            logger.error("Failed to undo action: %s", exc)
+
+
+def undo_all() -> None:
+    """Undo all registered actions in reverse order."""
+    while _UNDO_STACK:
+        undo_last()
+
+
+__all__ = [
+    "command_allowed",
+    "app_allowed",
+    "domain_allowed",
+    "confirm",
+    "register_undo",
+    "undo_last",
+    "undo_all",
+]

--- a/tests/test_os_guardian_action_engine.py
+++ b/tests/test_os_guardian_action_engine.py
@@ -35,7 +35,7 @@ sys.modules["selenium.webdriver"] = webdriver
 import importlib.util
 
 spec = importlib.util.spec_from_file_location(
-    "action_engine", ROOT / "os_guardian" / "action_engine.py"
+    "os_guardian.action_engine", ROOT / "os_guardian" / "action_engine.py"
 )
 action_engine = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = action_engine


### PR DESCRIPTION
## Summary
- add `safety` module with allowlists and undo helpers
- enforce policy confirmation in `action_engine`
- document permission variables
- update action engine tests for package import

## Testing
- `pytest -q tests/test_os_guardian_action_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6879529cdd28832e860b6458e2d6d381