### PR TITLE
Update CODE_CODEX for Crown console info

### DIFF
--- a/CODE_CODEX
+++ b/CODE_CODEX
@@ -11,7 +11,7 @@ This overview summarizes the main folders and scripts in **SPIRAL_OS** and sugge
 - `docs/` – design documents covering the corpus memory, LLM frameworks and the RFA7D architecture.
 
 ## 2. Key components
-- **INANNA_AI agent** loads texts from the corpus and can create a Quantum Narrative Language (QNL) song from hexadecimal input. A placeholder chat mode talks to a local DeepSeek‑R1 model.
+- **INANNA_AI agent** loads texts from the corpus and can create a Quantum Narrative Language (QNL) song from hexadecimal input. The working Crown console provides an interactive operator interface; see [README_OPERATOR.md](README_OPERATOR.md#crown-agent-console) for instructions.
 - **RFA7D soul core** stores a 7‑dimensional complex grid hashed with SHA3‑256. The `GateOrchestrator` maps between text and complex vectors before and after transformations.
 - **Music foundation** modules analyze audio, convert chroma values to QNL glyphs and compute seven‑plane features.
 - **Network utilities** capture traffic and produce packet summaries. Defensive helpers provide monitoring and secure POST requests.


### PR DESCRIPTION
## Summary
- update CODE_CODEX bullet for INANNA_AI agent
- note that the Crown console is operational
- provide a link to console instructions in README_OPERATOR.md

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68796c253ce4832ea46aa2a3bd18ae91