### PR TITLE
Add voice aura documentation

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -455,6 +455,13 @@ learning_mutator.py --activate citrinitas_layer
 The selected layer and recent emotional analysis are stored in
 `data/emotion_state.json` for review.
 
+### Voice Aura FX
+
+`voice_aura.py` selects a reverb and delay preset for the active emotion and
+applies it with `sox` when available. If `sox` is missing the script falls back
+to `pydub`.  Optional RAVE or NSynth checkpoints can further blend the timbre
+via `dsp_engine.rave_morph` or `nsynth_interpolate`.
+
 ### Fetch Project Gutenberg texts
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,5 +36,6 @@ The `docs` directory contains reference material for Spiral OS.
 - [ritual_manifesto.md](ritual_manifesto.md)
 - [root_chakra_overview.md](root_chakra_overview.md)
 - [sonic_core_harmonics.md](sonic_core_harmonics.md)
+- [voice_aura.md](voice_aura.md)
 - [spiral_cortex_terminal.md](spiral_cortex_terminal.md)
 - [spiritual_architecture.md](spiritual_architecture.md)

--- a/docs/voice_aura.md
+++ b/docs/voice_aura.md
@@ -1,0 +1,19 @@
+# Voice Aura FX
+
+`voice_aura.py` applies subtle reverb and delay based on the current emotion.
+Each emotion maps to a simple preset:
+
+| Emotion  | Reverb | Delay |
+|---------|-------|------|
+| neutral | 20    | 100  |
+| joy     | 30    | 80   |
+| excited | 25    | 50   |
+| calm    | 50    | 150  |
+| sad     | 60    | 200  |
+| fear    | 70    | 120  |
+| stress  | 40    | 60   |
+
+The module checks if the `sox` command is available to process effects.
+If not, it falls back to `pydub`.  Optional RAVE or NSynth checkpoints can
+morph the timbre via `dsp_engine.rave_morph` or `nsynth_interpolate`.
+


### PR DESCRIPTION
## Summary
- describe voice aura FX presets in README_OPERATOR
- document the aura presets and required tools
- link new docs page from the index

## Testing
- `pytest -k voice_aura -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68796d7ee354832eab976889fd7f76fa