### PR TITLE
Add sacred input ingestion helper

### DIFF
--- a/docs/rag_pipeline.md
+++ b/docs/rag_pipeline.md
@@ -14,6 +14,8 @@ The Spiral retrieval pipeline turns local documents into embeddings so queries c
    python spiral_embedder.py --in chunks.json
    ```
    Use `--db-path` to override the default location given by `SPIRAL_VECTOR_PATH`.
+   The helper script `scripts/ingest_sacred_inputs.sh` runs steps 2 and 3 in one
+   go.
 4. Start the query router and ask a question:
    ```python
    from crown_query_router import route_query

--- a/scripts/ingest_sacred_inputs.sh
+++ b/scripts/ingest_sacred_inputs.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Parse and embed sacred input files into the vector database
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+TMP_FILE="$(mktemp)"
+
+python "$ROOT_DIR/rag_parser.py" --dir "$ROOT_DIR/sacred_inputs" > "$TMP_FILE"
+python "$ROOT_DIR/spiral_embedder.py" --in "$TMP_FILE"
+
+rm -f "$TMP_FILE"


### PR DESCRIPTION
## Summary
- add `ingest_sacred_inputs.sh` script to parse sacred inputs and insert them into the vector DB
- document helper script in `docs/rag_pipeline.md`

## Testing
- `pytest tests/test_rag_parser.py tests/test_spiral_vector_db.py -q`
- ❌ `pytest tests/test_rag_embedder.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68796efdacb8832ea1231c82ac78478b