### PR TITLE
Add startup prereq check

### DIFF
--- a/scripts/check_prereqs.sh
+++ b/scripts/check_prereqs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Verify that required external commands are available
+set -e
+
+missing=()
+for cmd in docker nc sox ffmpeg; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        missing+=("$cmd")
+    fi
+done
+
+if [ "${#missing[@]}" -ne 0 ]; then
+    echo "Missing required command(s): ${missing[*]}" >&2
+    exit 1
+fi
+
+printf "All prerequisites satisfied.\n"

--- a/start_crown_console.sh
+++ b/start_crown_console.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 cd "$ROOT"
 
+./scripts/check_prereqs.sh
+
 if [ -f "secrets.env" ]; then
     set -a
     # shellcheck source=/dev/null


### PR DESCRIPTION
## Summary
- add a script to check for docker, nc, sox and ffmpeg
- verify prerequisites before launching crown console

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68797d87d608832ea475a0ab0507ba60