### PR TITLE
Log avatar interaction

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -348,6 +348,12 @@ class MoGEOrchestrator:
             action = intent.get("action")
             if action == "show_avatar":
                 context_tracker.state.avatar_loaded = True
+                log_interaction(
+                    text,
+                    {"action": "show_avatar"},
+                    {"message": "avatar displayed"},
+                    "ok",
+                )
             if action == "start_call":
                 context_tracker.state.in_call = True
 


### PR DESCRIPTION
## Summary
- log avatar display when `show_avatar` is triggered
- add unit test for avatar logging

## Testing
- `pytest tests/test_orchestrator_memory.py::test_show_avatar_logging -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68797e201038832ea294fa7aed0d15d1