### PR TITLE
Update docs index for avatar console

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,5 +38,6 @@ The `docs` directory contains reference material for Spiral OS.
 - [root_chakra_overview.md](root_chakra_overview.md)
 - [sonic_core_harmonics.md](sonic_core_harmonics.md)
 - [voice_aura.md](voice_aura.md)
+- [../start_avatar_console.sh](../start_avatar_console.sh)
 - [spiral_cortex_terminal.md](spiral_cortex_terminal.md)
 - [spiritual_architecture.md](spiritual_architecture.md)


### PR DESCRIPTION
## Summary
- reference the avatar console startup script in documentation

## Testing
- `bash scripts/check_prereqs.sh` *(fails: Missing required commands)*
- `bash start_avatar_console.sh` *(fails: Missing required commands)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68797f1d6d4c832ebee79d7f7dc1468a