### PR TITLE
Improve crown router decision weighting

### DIFF
--- a/crown_router.py
+++ b/crown_router.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+import emotional_state
+import vector_memory
+
 from orchestrator import MoGEOrchestrator
 from crown_decider import decide_expression_options
 
@@ -14,6 +17,14 @@ def route_decision(
     orchestrator: MoGEOrchestrator | None = None,
 ) -> Dict[str, Any]:
     """Return combined routing decision for ``text``.
+
+    The function delegates model selection to :class:`MoGEOrchestrator` and
+    chooses expression options based on both the current emotion and recent
+    history.  Past ``expression_decision`` records are retrieved from
+    :mod:`vector_memory` and weighted higher when their stored ``soul_state``
+    matches :func:`emotional_state.get_soul_state`.  These weights influence the
+    final ``tts_backend`` and ``avatar_style`` choices in addition to the
+    baseline recommendation from :func:`crown_decider.decide_expression_options`.
 
     Parameters
     ----------
@@ -38,11 +49,38 @@ def route_decision(
         voice_modality=False,
         music_modality=False,
     )
-    opts = decide_expression_options(emotion_data.get("emotion", "neutral"))
+
+    emotion = emotion_data.get("emotion", "neutral")
+    opts = decide_expression_options(emotion)
+
+    soul = emotional_state.get_soul_state()
+    try:
+        records = vector_memory.search(
+            "",
+            filter={"type": "expression_decision", "emotion": emotion},
+            k=20,
+        )
+    except Exception:
+        records = []
+
+    backend_weights: Dict[str, float] = {opts.get("tts_backend", ""): 1.0}
+    avatar_weights: Dict[str, float] = {opts.get("avatar_style", ""): 1.0}
+    for rec in records:
+        w = 2.0 if soul and rec.get("soul_state") == soul else 1.0
+        b = rec.get("tts_backend")
+        a = rec.get("avatar_style")
+        if b:
+            backend_weights[b] = backend_weights.get(b, 0.0) + w
+        if a:
+            avatar_weights[a] = avatar_weights.get(a, 0.0) + w
+
+    tts_backend = max(backend_weights, key=backend_weights.get)
+    avatar_style = max(avatar_weights, key=avatar_weights.get)
+
     return {
         "model": result.get("model"),
-        "tts_backend": opts.get("tts_backend"),
-        "avatar_style": opts.get("avatar_style"),
+        "tts_backend": tts_backend,
+        "avatar_style": avatar_style,
         "aura": opts.get("aura"),
     }
 

--- a/tests/test_crown_router_memory.py
+++ b/tests/test_crown_router_memory.py
@@ -1,0 +1,75 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+# stub heavy dependencies potentially imported by orchestrator
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+dummy_np = types.ModuleType("numpy")
+dummy_np.asarray = lambda x, dtype=None: x
+dummy_np.linalg = types.SimpleNamespace(norm=lambda x: 1.0)
+sys.modules.setdefault("numpy", dummy_np)
+qlm_mod = types.ModuleType("MUSIC_FOUNDATION.qnl_utils")
+qlm_mod.quantum_embed = lambda t: [0.0]
+sys.modules.setdefault("MUSIC_FOUNDATION.qnl_utils", qlm_mod)
+sys.modules.setdefault("MUSIC_FOUNDATION", types.ModuleType("MUSIC_FOUNDATION"))
+sys.modules["MUSIC_FOUNDATION"].qnl_utils = qlm_mod
+
+# Provide a lightweight orchestrator before importing crown_router
+orch_mod = types.ModuleType("orchestrator")
+
+class DummyOrchestrator:
+    def route(self, *a, **k):
+        return {"model": "glm"}
+
+orch_mod.MoGEOrchestrator = DummyOrchestrator
+sys.modules.setdefault("orchestrator", orch_mod)
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_expression_memory_influences_choice(monkeypatch):
+    import crown_router
+    importlib.reload(crown_router)
+
+    # MoGEOrchestrator is provided by the stub module above
+    monkeypatch.setattr(crown_router.emotional_state, "get_soul_state", lambda: "awakened")
+    monkeypatch.setattr(
+        crown_router,
+        "decide_expression_options",
+        lambda e: {"tts_backend": "gtts", "avatar_style": "Plain", "aura": None},
+    )
+
+    records_a = [
+        {
+            "type": "expression_decision",
+            "emotion": "joy",
+            "tts_backend": "coqui",
+            "avatar_style": "Soprano",
+            "soul_state": "awakened",
+        }
+    ] * 2
+    monkeypatch.setattr(crown_router.vector_memory, "search", lambda *a, **k: records_a)
+
+    res = crown_router.route_decision("hi", {"emotion": "joy"})
+    assert res["tts_backend"] == "coqui"
+    assert res["avatar_style"] == "Soprano"
+
+    records_b = [
+        {
+            "type": "expression_decision",
+            "emotion": "joy",
+            "tts_backend": "gtts",
+            "avatar_style": "Baritone",
+            "soul_state": "awakened",
+        }
+    ] * 2
+    monkeypatch.setattr(crown_router.vector_memory, "search", lambda *a, **k: records_b)
+
+    res2 = crown_router.route_decision("hi", {"emotion": "joy"})
+    assert res2["tts_backend"] == "gtts"
+    assert res2["avatar_style"] == "Baritone"
+


### PR DESCRIPTION
## Summary
- search expression history when deciding text-to-speech options
- favor backends and avatar styles that match past successful soul states
- document the new weighting logic
- add a test covering memory influence on routing

## Testing
- `pytest -q tests/test_crown_router_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_6879fb3862b8832eb8db5c8307aa991b