### PR TITLE
Add Python Crown console launcher

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -541,6 +541,13 @@ open the interactive console once the endpoints are ready.
 ./start_crown_console.sh
 ```
 
+Alternatively run the Python wrapper to load `secrets.env`, start the
+console and streaming server, and wait for both processes:
+
+```bash
+python start_crown_console.py
+```
+
 After initialization the console displays the prompt:
 
 ```

--- a/start_crown_console.py
+++ b/start_crown_console.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Run Crown services and video stream with graceful shutdown."""
+from __future__ import annotations
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def main() -> None:
+    """Launch console and video stream then wait for exit."""
+    load_dotenv(ROOT / "secrets.env")
+
+    crown_proc = subprocess.Popen(["bash", str(ROOT / "start_crown_console.sh")])
+    stream_proc = subprocess.Popen([sys.executable, str(ROOT / "video_stream.py")])
+    procs = [crown_proc, stream_proc]
+
+    def _terminate(*_args: object) -> None:
+        for p in procs:
+            if p.poll() is None:
+                p.terminate()
+        for p in procs:
+            try:
+                p.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                p.kill()
+
+    signal.signal(signal.SIGINT, _terminate)
+    signal.signal(signal.SIGTERM, _terminate)
+
+    try:
+        while any(p.poll() is None for p in procs):
+            time.sleep(0.5)
+    finally:
+        _terminate()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_start_crown_console_py.py
+++ b/tests/test_start_crown_console_py.py
@@ -1,0 +1,59 @@
+import importlib.util
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_python_crown_console(monkeypatch):
+    calls: list[str] = []
+
+    module_path = ROOT / "start_crown_console.py"
+    loader = SourceFileLoader("start_crown_console", str(module_path))
+    spec = importlib.util.spec_from_loader("start_crown_console", loader)
+    mod = importlib.util.module_from_spec(spec)
+    dummy_dotenv = types.SimpleNamespace(load_dotenv=lambda *_: None)
+    monkeypatch.setitem(sys.modules, "dotenv", dummy_dotenv)
+    loader.exec_module(mod)
+
+    def fake_sleep(_):
+        # Simulate one loop iteration
+        for p in procs:
+            polls[p] = 0
+
+    polls: dict[object, int] = {}
+    procs: list[object] = []
+
+    class DummyProc:
+        def __init__(self, args: list[str]):
+            self.args = args
+            procs.append(self)
+            polls[self] = None
+            calls.append(" ".join(args))
+
+        def poll(self):
+            return polls[self]
+
+        def terminate(self):
+            calls.append(f"term {' '.join(self.args)}")
+
+        def wait(self, timeout=None):
+            calls.append(f"wait {' '.join(self.args)}")
+
+    def fake_popen(args, *a, **k):
+        return DummyProc(args)
+
+    dummy_dotenv = types.SimpleNamespace(load_dotenv=lambda *_: None)
+    monkeypatch.setitem(sys.modules, "dotenv", dummy_dotenv)
+    monkeypatch.setattr(mod.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(mod, "load_dotenv", dummy_dotenv.load_dotenv)
+    monkeypatch.setattr(mod.time, "sleep", fake_sleep)
+
+    mod.main()
+
+    assert f"bash {ROOT / 'start_crown_console.sh'}" in calls[0]
+    assert sys.executable in calls[1]
+    assert str(ROOT / "video_stream.py") in calls[1]
+    assert any(c.startswith("wait ") for c in calls)


### PR DESCRIPTION
## Summary
- add `start_crown_console.py` to run the console and video stream
- document Python launcher in README_OPERATOR.md
- test new script with `test_start_crown_console_py.py`

## Testing
- `pytest tests/test_start_crown_console_py.py -q`
- `pip install numpy httpx markdown soundfile librosa pytest --quiet` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687a044a82d8832ea50e5a19a47d81dc