### PR TITLE
Update docs for memory-aided routing and session logger

### DIFF
--- a/docs/CROWN_OVERVIEW.md
+++ b/docs/CROWN_OVERVIEW.md
@@ -32,3 +32,11 @@ User commands enter through the **Crown Console**. The **Crown Agent** sends
 requests to the GLM service and keeps recent history in memory. The
 **State Transition Engine** tracks ritual phrases and emotional cues. It may
 delegate a prompt to one of the registered servant models when appropriate.
+
+## Memory‑Aided Routing
+
+The Crown router looks up previous expression decisions in `vector_memory`. When the stored `soul_state` aligns with the current emotion, the corresponding voice backend and avatar style are weighted higher. This memory‑aided approach keeps responses consistent with past interactions.
+
+## Session Logger
+
+Running the console interface now writes audio clips under `logs/audio/` and avatar frames to `logs/video/`. These helpers live in `tools/session_logger.py` and make it easier to review how voice modulation and streaming evolve across sessions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 The `docs` directory contains reference material for Spiral OS.
 
+Milestone VIII expands on the sovereign voice work with memory-aided routing and a new session logger. See [milestone_viii_plan.md](milestone_viii_plan.md) for the design and [../README_OPERATOR.md](../README_OPERATOR.md) for updated commands.
+
 - [ALBEDO_LAYER.md](ALBEDO_LAYER.md)
 - [CORPUS_MEMORY.md](CORPUS_MEMORY.md)
 - [CROWN_OVERVIEW.md](CROWN_OVERVIEW.md)


### PR DESCRIPTION
## Summary
- describe memory-aided routing and session logger in the Crown overview
- mention milestone VIII changes in the docs index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -r tests/requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy)*
- `bash start_avatar_console.sh` *(fails: Missing required command(s): docker sox ffmpeg)*

------
https://chatgpt.com/codex/tasks/task_e_687a0606cd4c832ea33b74b5dc8074a3