### PR TITLE
Update GLM endpoint defaults

### DIFF
--- a/INANNA_AI/existential_reflector.py
+++ b/INANNA_AI/existential_reflector.py
@@ -17,7 +17,7 @@ INANNA_DIR = ROOT / "INANNA_AI"
 QNL_DIR = ROOT / "QNL_LANGUAGE"
 AUDIT_DIR = ROOT / "audit_logs"
 INSIGHTS_FILE = AUDIT_DIR / "existential_insights.txt"
-ENDPOINT = os.getenv("GLM_API_URL", "https://api.example.com/glm")
+ENDPOINT = os.getenv("GLM_API_URL", "http://localhost:8001/glm")
 API_KEY = os.getenv("GLM_API_KEY")
 HEADERS = {"Authorization": f"Bearer {API_KEY}"} if API_KEY else None
 

--- a/INANNA_AI/glm_integration.py
+++ b/INANNA_AI/glm_integration.py
@@ -12,7 +12,7 @@ except Exception:  # pragma: no cover - fallback when requests missing
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_ENDPOINT = "https://api.example.com/glm41v_9b"
+DEFAULT_ENDPOINT = "http://localhost:8001"
 SAFE_ERROR_MESSAGE = "GLM unavailable"
 
 

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -144,7 +144,13 @@ background tasks.
    for example `./run_inanna.sh --model-dir INANNA_AI/models/gemma2`.
 4. Optionally configure `GLMIntegration` with your GLM endpoint and API key.  If
    no values are provided the class reads `GLM_API_URL` and `GLM_API_KEY` from
-   the environment and defaults to `https://api.example.com/glm41v_9b`.
+   the environment and defaults to `http://localhost:8001`.
+   Set them explicitly before starting chat:
+
+   ```bash
+   export GLM_API_URL=http://localhost:8001
+   export GLM_API_KEY=<your key>
+   ```
 
 ## Download Models
 

--- a/config/INANNA_CORE.yaml
+++ b/config/INANNA_CORE.yaml
@@ -8,7 +8,7 @@
 #   MISTRAL_URL   -> servant_models.mistral
 #   KIMI_K2_URL   -> servant_models.kimi_k2
 
-glm_api_url: https://api.example.com/glm41v_9b
+glm_api_url: http://localhost:8001
 glm_api_key: your-api-key
 model_path: INANNA_AI/models/GLM-4.1V-9B
 memory_dir: data/vector_memory

--- a/docs/ALBEDO_LAYER.md
+++ b/docs/ALBEDO_LAYER.md
@@ -16,11 +16,12 @@ The **Albedo** layer introduces a stateful persona that drives responses through
 `GLMIntegration` reads the endpoint and API key from environment variables by default.  Override them when instantiating the class or set `GLM_API_URL` and `GLM_API_KEY`:
 
 ```python
+import os
 from INANNA_AI.glm_integration import GLMIntegration
 
 glm = GLMIntegration(
-    endpoint="https://api.example.com/glm41v_9b",
-    api_key="<your key>",
+    endpoint=os.getenv("GLM_API_URL", "http://localhost:8001"),
+    api_key=os.getenv("GLM_API_KEY"),
 )
 ```
 
@@ -33,8 +34,8 @@ When no arguments are provided the class falls back to the `GLM_API_URL` and
 To engage the Albedo personality, create the layer and pass it to the orchestrator. The `INANNA_AI.main` script records microphone input and routes it through this layer:
 
 ```bash
+export GLM_API_URL=http://localhost:8001
 export GLM_API_KEY=<your key>
-export GLM_API_URL=https://api.example.com/glm41v_9b
 python -m INANNA_AI.main --duration 3 --personality albedo
 ```
 

--- a/docs/INANNA_CORE.md
+++ b/docs/INANNA_CORE.md
@@ -28,7 +28,7 @@
 ## Example
 
 ```yaml
-glm_api_url: https://api.example.com/glm41v_9b
+glm_api_url: http://localhost:8001
 glm_api_key: your-api-key
 model_path: INANNA_AI/models/GLM-4.1V-9B
 memory_dir: data/vector_memory
@@ -40,3 +40,9 @@ servant_models:
 
 Environment variables with the same names as listed above override the
 corresponding entries when `init_crown_agent.initialize_crown()` loads the file.
+Set `GLM_API_URL` and `GLM_API_KEY` explicitly before launching:
+
+```bash
+export GLM_API_URL=http://localhost:8001
+export GLM_API_KEY=your-api-key
+```

--- a/init_crown_agent.py
+++ b/init_crown_agent.py
@@ -86,6 +86,8 @@ def _init_memory(cfg: dict) -> None:
 
 
 def _check_glm(integration: GLMIntegration) -> None:
+    if not integration.endpoint:
+        raise RuntimeError("GLM_API_URL not configured")
     try:
         resp = integration.complete("ping")
     except Exception as exc:  # pragma: no cover - network errors
@@ -127,10 +129,9 @@ def _init_servants(cfg: dict) -> None:
 def initialize_crown() -> GLMIntegration:
     """Return a :class:`GLMIntegration` instance configured from YAML."""
     cfg = _load_config()
-    integration = GLMIntegration(
-        endpoint=cfg.get("glm_api_url"),
-        api_key=cfg.get("glm_api_key"),
-    )
+    endpoint = os.getenv("GLM_API_URL", cfg.get("glm_api_url"))
+    api_key = os.getenv("GLM_API_KEY", cfg.get("glm_api_key"))
+    integration = GLMIntegration(endpoint=endpoint, api_key=api_key)
     if cfg.get("model_path"):
         os.environ.setdefault("MODEL_PATH", str(cfg["model_path"]))
     _init_memory(cfg)


### PR DESCRIPTION
## Summary
- default GLM endpoint to localhost
- surface GLM API env vars in docs and examples
- read `GLM_API_URL` and `GLM_API_KEY` explicitly during initialization and fail if unavailable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a0938aff0832e93025db4ff297112