### PR TITLE
Enhance seven plane analysis

### DIFF
--- a/tests/test_seven_dimensional_music_analysis.py
+++ b/tests/test_seven_dimensional_music_analysis.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from SPIRAL_OS import seven_dimensional_music as sdm
+
+
+def test_analyze_seven_planes_populated():
+    sr = 22050
+    t = np.linspace(0, 0.5, sr // 2, endpoint=False)
+    wave = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+    planes = sdm.analyze_seven_planes(wave, sr)
+    expected = {
+        "physical",
+        "emotional",
+        "mental",
+        "astral",
+        "etheric",
+        "celestial",
+        "divine",
+    }
+    assert set(planes) == expected
+    for val in planes.values():
+        assert isinstance(val, dict)
+        assert val


### PR DESCRIPTION
## Summary
- compute spectral features in `seven_dimensional_music.analyze_seven_planes`
- document returned metrics
- add a unit test for `analyze_seven_planes`

## Testing
- `pytest -q tests/test_seven_dimensional_music_analysis.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a0cc33c38832ebecc0bf87948d47c