### PR TITLE
Remove DummyModel and enforce weight download

### DIFF
--- a/INANNA_AI_AGENT/model.py
+++ b/INANNA_AI_AGENT/model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Tuple
 
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
 def load_model(model_dir: str | Path) -> Tuple[object, AutoTokenizer]:
@@ -22,18 +22,14 @@ def load_model(model_dir: str | Path) -> Tuple[object, AutoTokenizer]:
     model_dir = Path(model_dir)
     tokenizer = AutoTokenizer.from_pretrained(model_dir, local_files_only=True)
     try:
-        model = AutoModelForCausalLM.from_pretrained(model_dir, local_files_only=True)
-    except Exception:
-        config = AutoConfig.from_pretrained(model_dir, local_files_only=True)
-
-        class DummyModel:
-            def __init__(self, cfg):
-                self.config = cfg
-
-            def generate(self, **kwargs):  # pragma: no cover - placeholder
-                return [[0]]
-
-        model = DummyModel(config)
+        model = AutoModelForCausalLM.from_pretrained(
+            model_dir, local_files_only=True
+        )
+    except Exception as exc:
+        raise FileNotFoundError(
+            f"Model weights not found in {model_dir}. "
+            "Run download_models.py to fetch them."
+        ) from exc
     return model, tokenizer
 
 

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -146,6 +146,7 @@ background tasks.
    The `run_inanna.sh` helper script reads this file when starting the chat
    agent.
 2. Run `python download_models.py deepseek` to fetch the DeepSeek-R1 model.
+   This download **must** complete before the chat agent can run.
 3. Start chat via `python INANNA_AI_AGENT/inanna_ai.py chat` or `./run_inanna.sh`.
    To load a different model directory pass `--model-dir <path>` to either command,
    for example `./run_inanna.sh --model-dir INANNA_AI/models/gemma2`.
@@ -161,8 +162,10 @@ background tasks.
 
 ## Download Models
 
-The INANNA chat agent requires the DeepSeek-R1 weights from Hugging Face. Follow
-these steps to place the model under `INANNA_AI/models`.
+The INANNA chat agent requires the DeepSeek-R1 weights from Hugging Face.
+Download them **before** running the chat command or the loader will raise a
+`FileNotFoundError`. Follow these steps to place the model under
+`INANNA_AI/models`.
 
 1. Install the dependencies using the optional development extras:
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,6 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from INANNA_AI_AGENT import model  # type: ignore
+import pytest
 
 from transformers import GPT2Config, GPT2LMHeadModel, PreTrainedTokenizerFast
 from tokenizers import Tokenizer
@@ -37,3 +38,8 @@ def test_load_model_returns_objects(tmp_path):
     mdl, tok = model.load_model(tmp_path)
     assert mdl is not None
     assert tok is not None
+
+
+def test_load_model_missing_weights(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        model.load_model(tmp_path)


### PR DESCRIPTION
## Summary
- drop DummyModel fallback from `load_model`
- raise `FileNotFoundError` if model weights are absent
- clarify in the operator guide that models must be downloaded before using chat
- test the missing-weight error condition

## Testing
- `pytest tests/test_model.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687a0e2092e4832e8449032a6b0bbd9e