### PR TITLE
Add ETHICS_GUIDELINES and update setup

### DIFF
--- a/ETHICS_GUIDELINES.md
+++ b/ETHICS_GUIDELINES.md
@@ -1,0 +1,5 @@
+# Ethics Guidelines v1
+
+This directory stores assets for the INANNA_AI and QNL_LANGUAGE modules.
+Ensure all data complies with ethical guidelines.
+Use resources responsibly and respect copyright.

--- a/docs/VAST_DEPLOYMENT.md
+++ b/docs/VAST_DEPLOYMENT.md
@@ -50,7 +50,9 @@ Run the setup script to install Python packages and create core directories unde
 bash scripts/setup_glm.sh
 ```
 
-It prepares `/INANNA_AI`, `/QNL_LANGUAGE` and `/audit_logs` with placeholder ethics notes.
+It prepares `/INANNA_AI`, `/QNL_LANGUAGE` and `/audit_logs`. The script copies
+`ETHICS_GUIDELINES.md` into the first two directories so the guidelines are
+always available on the server.
 
 ## Clone a private repository
 

--- a/scripts/setup_glm.sh
+++ b/scripts/setup_glm.sh
@@ -10,16 +10,9 @@ mkdir -p /INANNA_AI
 mkdir -p /QNL_LANGUAGE
 mkdir -p /audit_logs
 
-# placeholder ethical guideline files
-cat <<'EON' > /INANNA_AI/ETHICS_PLACEHOLDER.txt
-This directory stores INANNA_AI assets.
-Ensure all data complies with ethical guidelines.
-EON
-
-cat <<'EON' > /QNL_LANGUAGE/ETHICS_PLACEHOLDER.txt
-This directory holds QNL language resources.
-Use responsibly and respect copyright.
-EON
+# copy ethics guidelines
+cp "$(dirname "$0")/../ETHICS_GUIDELINES.md" /INANNA_AI/ETHICS_GUIDELINES.md
+cp "$(dirname "$0")/../ETHICS_GUIDELINES.md" /QNL_LANGUAGE/ETHICS_GUIDELINES.md
 
 cat <<'EON' > /audit_logs/README.txt
 Audit logs for monitoring system behavior.


### PR DESCRIPTION
## Summary
- add versioned `ETHICS_GUIDELINES.md`
- copy the file in `setup_glm.sh` instead of writing placeholders
- document the new behaviour in `docs/VAST_DEPLOYMENT.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a1236bd94832eb3bdd9478e0bd702