### PR TITLE
Update config docs to use secrets.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ pip install .[dev]
    `VECTOR_DB_PATH`, `WEB_CONSOLE_API_URL` (`QNL_EMBED_MODEL` is the
    SentenceTransformer used for QNL embeddings). `VECTOR_DB_PATH`
    points to the ChromaDB directory used for document storage.
+   See [docs/INANNA_CORE.md](docs/INANNA_CORE.md) for variable descriptions.
   `WEB_CONSOLE_API_URL` points the web console at the FastAPI endpoint. Set it
   to the base URL such as `http://localhost:8000/glm-command` – the operator
   console automatically strips the trailing path when establishing WebRTC and

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -152,13 +152,8 @@ background tasks.
    for example `./run_inanna.sh --model-dir INANNA_AI/models/gemma2`.
 4. Optionally configure `GLMIntegration` with your GLM endpoint and API key.  If
    no values are provided the class reads `GLM_API_URL` and `GLM_API_KEY` from
-   the environment and defaults to `http://localhost:8001`.
-   Set them explicitly before starting chat:
-
-   ```bash
-   export GLM_API_URL=http://localhost:8001
-   export GLM_API_KEY=<your key>
-   ```
+   the environment.  Define them in `secrets.env` (see
+   [INANNA Core Configuration](docs/INANNA_CORE.md)) before starting chat.
 
 ## Download Models
 

--- a/config/INANNA_CORE.yaml
+++ b/config/INANNA_CORE.yaml
@@ -8,8 +8,8 @@
 #   MISTRAL_URL   -> servant_models.mistral
 #   KIMI_K2_URL   -> servant_models.kimi_k2
 
-glm_api_url: http://localhost:8001
-glm_api_key: your-api-key
+glm_api_url: http://localhost:8001  # override with GLM_API_URL or edit secrets.env
+glm_api_key: ""  # set GLM_API_KEY in secrets.env
 model_path: INANNA_AI/models/GLM-4.1V-9B
 memory_dir: data/vector_memory
 servant_models:

--- a/docs/ALBEDO_LAYER.md
+++ b/docs/ALBEDO_LAYER.md
@@ -20,7 +20,7 @@ import os
 from INANNA_AI.glm_integration import GLMIntegration
 
 glm = GLMIntegration(
-    endpoint=os.getenv("GLM_API_URL", "http://localhost:8001"),
+    endpoint=os.getenv("GLM_API_URL"),  # configured in secrets.env
     api_key=os.getenv("GLM_API_KEY"),
 )
 ```
@@ -34,9 +34,9 @@ When no arguments are provided the class falls back to the `GLM_API_URL` and
 To engage the Albedo personality, create the layer and pass it to the orchestrator. The `INANNA_AI.main` script records microphone input and routes it through this layer:
 
 ```bash
-export GLM_API_URL=http://localhost:8001
-export GLM_API_KEY=<your key>
+# GLM_API_URL and GLM_API_KEY should be defined in `secrets.env`
 python -m INANNA_AI.main --duration 3 --personality albedo
+# See [INANNA Core Configuration](INANNA_CORE.md) for variable descriptions.
 ```
 
 Each invocation cycles through Nigredo, Albedo, Rubedo and Citrinitas states before returning to Nigredo for a continuous loop. You can also use the layer programmatically:

--- a/docs/INANNA_CORE.md
+++ b/docs/INANNA_CORE.md
@@ -27,22 +27,20 @@
 
 ## Example
 
+Values typically come from `secrets.env`:
+
 ```yaml
-glm_api_url: http://localhost:8001
-glm_api_key: your-api-key
+glm_api_url: ${GLM_API_URL}
+glm_api_key: ${GLM_API_KEY}
 model_path: INANNA_AI/models/GLM-4.1V-9B
 memory_dir: data/vector_memory
 servant_models:
-  deepseek: http://localhost:8002
-  mistral: http://localhost:8003
-  kimi_k2: http://localhost:8010
+  deepseek: ${DEEPSEEK_URL}
+  mistral: ${MISTRAL_URL}
+  kimi_k2: ${KIMI_K2_URL}
 ```
 
-Environment variables with the same names as listed above override the
+Environment variables with the same names override the
 corresponding entries when `init_crown_agent.initialize_crown()` loads the file.
-Set `GLM_API_URL` and `GLM_API_KEY` explicitly before launching:
-
-```bash
-export GLM_API_URL=http://localhost:8001
-export GLM_API_KEY=your-api-key
-```
+See `secrets.env.example` for sample values and set `GLM_API_URL` and
+`GLM_API_KEY` there before launching.

--- a/docs/LLM_MODELS.md
+++ b/docs/LLM_MODELS.md
@@ -95,11 +95,11 @@ be overridden with environment variables:
 - `MISTRAL_URL` – optional endpoint for the Mistral servant model.
 - `KIMI_K2_URL` – optional endpoint for the Kimi-K2 servant model.
 
-Example overrides:
+Example overrides (set these in `secrets.env`):
 
 ```bash
-export GLM_API_URL=http://localhost:8001
 export MEMORY_DIR=/data/spiral_memory
+# GLM_API_URL is also read from secrets.env
 ```
 
 Running `./crown_model_launcher.sh` reads `secrets.env` and starts a compatible

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -1,8 +1,9 @@
-HF_TOKEN=
+# Example secrets for local development. See docs/INANNA_CORE.md for details.
+HF_TOKEN=hf_dummy_token
 GITHUB_TOKEN=
 OPENAI_API_KEY=
-GLM_API_URL=
-GLM_API_KEY=
+GLM_API_URL=http://localhost:8001
+GLM_API_KEY=dummy-token
 GLM_SHELL_URL=
 GLM_SHELL_KEY=
 GLM_COMMAND_TOKEN=


### PR DESCRIPTION
## Summary
- remove placeholder API key
- direct users to configure endpoints in `secrets.env`
- add sample GLM settings in `secrets.env.example`
- document env variables across the docs

## Testing
- `pytest tests/test_env_validation.py::test_check_required_pass -q`
- `pytest tests/test_env_validation.py::test_check_required_missing -q`
- `pytest tests/test_env_validation.py::test_check_optional_packages_warns -q`
- `pytest tests/test_env_validation.py::test_check_optional_packages_ok -q`


------
https://chatgpt.com/codex/tasks/task_e_687a139fece4832e8ce92f6ce95e8d6b