### PR TITLE
Add tests for fallback_tts and GLM connectivity

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,3 +43,5 @@ Milestone VIII expands on the sovereign voice work with memory-aided routing and
 - [../start_avatar_console.sh](../start_avatar_console.sh)
 - [spiral_cortex_terminal.md](spiral_cortex_terminal.md)
 - [spiritual_architecture.md](spiritual_architecture.md)
+
+Recent updates add tests for the fallback text-to-speech helper and verify connectivity to the GLM service during initialization.

--- a/tests/test_fallback_tts_module.py
+++ b/tests/test_fallback_tts_module.py
@@ -1,0 +1,61 @@
+import sys
+from pathlib import Path
+import types
+
+# Provide dummy numpy so fallback_tts can import
+np_stub = types.ModuleType("numpy")
+np_stub.linspace = lambda start, stop, num, endpoint=False: [0.0] * num
+np_stub.sin = lambda arr: [0.0 for _ in arr]
+np_stub.pi = 3.14159
+np_stub.float32 = float
+sys.modules.setdefault("numpy", np_stub)
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from INANNA_AI import fallback_tts
+
+
+def test_sine_wave_used_when_pyttsx3_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(fallback_tts, "pyttsx3", None)
+    called = {}
+
+    def fake_sine(text: str, path: Path, pitch: float) -> None:
+        called["args"] = (text, path, pitch)
+        Path(path).write_bytes(b"x")
+
+    monkeypatch.setattr(fallback_tts, "_sine_wave", fake_sine)
+    monkeypatch.setattr(fallback_tts.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    out = fallback_tts.speak("hello", pitch=0.5)
+    assert Path(out).exists()
+    assert called["args"] == ("hello", Path(out), 0.5)
+
+
+def test_pyttsx3_failure_falls_back(tmp_path, monkeypatch):
+    class DummyEngine:
+        def save_to_file(self, text, path):
+            pass
+        def runAndWait(self):
+            raise RuntimeError("fail")
+        def getProperty(self, name):
+            return 100
+        def setProperty(self, name, value):
+            pass
+
+    dummy_mod = types.SimpleNamespace(init=lambda: DummyEngine())
+    called = {}
+
+    def fake_sine(text: str, path: Path, pitch: float) -> None:
+        called["args"] = (text, path, pitch)
+        Path(path).write_bytes(b"x")
+
+    monkeypatch.setattr(fallback_tts, "pyttsx3", dummy_mod)
+    monkeypatch.setattr(fallback_tts, "_sine_wave", fake_sine)
+    monkeypatch.setattr(fallback_tts.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    out = fallback_tts.speak("hi", pitch=-0.2)
+    assert Path(out).exists()
+    assert called["args"] == ("hi", Path(out), -0.2)

--- a/tests/test_glm_connectivity.py
+++ b/tests/test_glm_connectivity.py
@@ -1,0 +1,43 @@
+import sys
+import types
+from pathlib import Path
+import pytest
+
+# Stub modules required by init_crown_agent import
+sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+sys.modules.setdefault("vector_memory", types.ModuleType("vector_memory"))
+sys.modules.setdefault("INANNA_AI.corpus_memory", types.ModuleType("corpus_memory"))
+sys.modules.setdefault("servant_model_manager", types.ModuleType("servant_model_manager"))
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import init_crown_agent
+import INANNA_AI.glm_integration as gi
+
+
+def test_check_glm_success(caplog):
+    integration = types.SimpleNamespace(endpoint="http://x", complete=lambda p: "pong")
+    with caplog.at_level("INFO"):
+        init_crown_agent._check_glm(integration)
+    assert any("GLM test response" in r.message for r in caplog.records)
+
+
+def test_check_glm_no_url():
+    integration = types.SimpleNamespace(endpoint="", complete=lambda p: "pong")
+    with pytest.raises(RuntimeError):
+        init_crown_agent._check_glm(integration)
+
+
+def test_check_glm_network_error():
+    def raise_err(p):
+        raise ValueError("boom")
+    integration = types.SimpleNamespace(endpoint="http://x", complete=raise_err)
+    with pytest.raises(RuntimeError):
+        init_crown_agent._check_glm(integration)
+
+
+def test_check_glm_error_message():
+    integration = types.SimpleNamespace(endpoint="http://x", complete=lambda p: gi.SAFE_ERROR_MESSAGE)
+    with pytest.raises(RuntimeError):
+        init_crown_agent._check_glm(integration)


### PR DESCRIPTION
## Summary
- test fallback_tts helper module
- test the GLM connectivity check logic
- document new tests in docs/README.md

## Testing
- `pytest -q tests/test_fallback_tts_module.py tests/test_glm_connectivity.py`
- `pytest -q` *(fails: 47 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a154b6160832eae0b8fd79cba65cb