### PR TITLE
Add health check for LLM services

### DIFF
--- a/scripts/check_services.sh
+++ b/scripts/check_services.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Query /health and /ready for each configured LLM service.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Load environment variables if not already set
+if [ -f "$ROOT_DIR/secrets.env" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ROOT_DIR/secrets.env"
+    set +a
+fi
+
+check_service() {
+    local base="${1%/}"
+    for path in health ready; do
+        if ! curl -fsS -m 5 "$base/$path" >/dev/null; then
+            echo "Service at $base failed $path check" >&2
+            return 1
+        fi
+    done
+}
+
+failed=0
+for url in "$GLM_API_URL" "${DEEPSEEK_URL:-}" "${MISTRAL_URL:-}" "${KIMI_K2_URL:-}"; do
+    [ -n "$url" ] || continue
+    echo "Checking $url..."
+    if ! check_service "$url"; then
+        echo "Service $url not responding" >&2
+        failed=1
+    fi
+done
+
+if [ "$failed" -ne 0 ]; then
+    exit 1
+fi
+
+echo "All services are healthy."

--- a/start_crown_console.sh
+++ b/start_crown_console.sh
@@ -69,4 +69,6 @@ for url in "${DEEPSEEK_URL:-}" "${MISTRAL_URL:-}" "${KIMI_K2_URL:-}"; do
     fi
 done
 
+./scripts/check_services.sh
+
 python console_interface.py

--- a/tests/test_crown_console_startup.py
+++ b/tests/test_crown_console_startup.py
@@ -26,6 +26,7 @@ def test_crown_console_startup(monkeypatch):
                     "crown_model_launcher",
                     "launch_servants",
                     "nc -z localhost 8000",
+                    "scripts/check_services.sh",
                     "python console_interface.py",
                 ]
             )
@@ -43,10 +44,13 @@ def test_crown_console_startup(monkeypatch):
     assert result.returncode == 0
     assert "crown_model_launcher" in calls
     assert "launch_servants" in calls
+    assert "scripts/check_services.sh" in calls
     assert "python console_interface.py" in calls
     launcher_idx = calls.index("crown_model_launcher")
     servants_idx = calls.index("launch_servants")
     console_idx = calls.index("python console_interface.py")
+    check_idx = calls.index("scripts/check_services.sh")
+    port_idx = calls.index("nc -z localhost 8000")
 
     assert launcher_idx < servants_idx
-    assert servants_idx < console_idx
+    assert servants_idx < port_idx < check_idx < console_idx

--- a/tests/test_start_avatar_console.py
+++ b/tests/test_start_avatar_console.py
@@ -29,6 +29,7 @@ def test_start_avatar_console_waits_and_fallback(monkeypatch):
                 calls.append("nc -z localhost 8000")
             else:
                 calls.append("python socket_check")
+            calls.append("scripts/check_services.sh")
             calls.append("python console_interface.py")
         return subprocess.CompletedProcess(cmd, 0, "", "")
 
@@ -50,4 +51,5 @@ def test_start_avatar_console_waits_and_fallback(monkeypatch):
     assert wait_idx > calls.index("start_crown_console")
     assert wait_idx > calls.index("python video_stream.py")
     assert "python socket_check" in calls
+    assert "scripts/check_services.sh" in calls
 


### PR DESCRIPTION
## Summary
- add `scripts/check_services.sh` to query `/health` and `/ready`
- update `start_crown_console.sh` to run this script before the console
- adjust console startup tests for the new check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a1801c910832e9edc82605ed7e436