### PR TITLE
Document Vast.ai ports

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -76,6 +76,21 @@ Configuration options for `config/INANNA_CORE.yaml` and the corresponding
 environment variables are explained in
 [docs/INANNA_CORE.md](docs/INANNA_CORE.md).
 
+### Adaptación para Vast.ai
+
+En un servidor Vast.ai normalmente se utilizan los siguientes puertos:
+
+- `8000` para la interfaz FastAPI.
+- `8001` para el servicio GLM principal.
+- `8002` para DeepSeek.
+- `8003` para Mistral.
+- `8010` para Kimi‑K2.
+
+Los modelos suelen almacenarse bajo `/workspace/THESPIRAL/INANNA_AI/models`.
+Establezca en `secrets.env` las URLs de cada servicio con la IP pública de la
+instancia, por ejemplo `GLM_API_URL=http://<ip>:8001`. Ajuste de igual forma
+`DEEPSEEK_URL`, `MISTRAL_URL` y `KIMI_K2_URL` si están activos.
+
 ## Script overview
 
 - **`INANNA_AI_AGENT/inanna_ai.py`** – Activation agent that loads source texts and can recite the INANNA birth chant or feed hex data into the QNL engine. Use `--list` to show available texts.

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -1,23 +1,33 @@
 # Example secrets for local development. See docs/INANNA_CORE.md for details.
+# When running on a Vast.ai server the repository usually resides under
+# `/workspace/THESPIRAL`. Recommended service ports are:
+#   8000 - FastAPI interface
+#   8001 - GLM service
+#   8002 - DeepSeek servant
+#   8003 - Mistral servant
+#   8010 - Kimi-K2 servant
+# Model weights can be placed under `/workspace/THESPIRAL/INANNA_AI/models`.
 HF_TOKEN=hf_dummy_token
 GITHUB_TOKEN=
 OPENAI_API_KEY=
-GLM_API_URL=http://localhost:8001
+GLM_API_URL=http://localhost:8001  # use http://<ip>:8001 on Vast.ai
 GLM_API_KEY=dummy-token
-GLM_SHELL_URL=
+GLM_SHELL_URL=  # e.g. http://<ip>:8011
 GLM_SHELL_KEY=
 GLM_COMMAND_TOKEN=
 REFLECTION_INTERVAL=
 CORPUS_PATH=
 QNL_EMBED_MODEL=all-MiniLM-L6-v2
-QNL_MODEL_PATH=
-EMBED_MODEL_PATH=
-VOICE_TONE_PATH=
+QNL_MODEL_PATH=  # e.g. /workspace/THESPIRAL/INANNA_AI/models/qnl
+EMBED_MODEL_PATH=  # e.g. /workspace/THESPIRAL/INANNA_AI/models/embedder
+VOICE_TONE_PATH=  # e.g. /workspace/THESPIRAL/data/voice_tones
 VECTOR_DB_PATH=
 RETRAIN_THRESHOLD=
 VOICE_CONFIG_PATH=
 EMOTION_STATE_PATH=
-KIMI_K2_URL=
+DEEPSEEK_URL=  # e.g. http://<ip>:8002
+MISTRAL_URL=   # e.g. http://<ip>:8003
+KIMI_K2_URL=  # e.g. http://<ip>:8010
 LLM_ROTATION_PERIOD=300
 LLM_MAX_FAILURES=3
 ARCHETYPE_STATE=ALBEDO


### PR DESCRIPTION
## Summary
- document how to adapt environment variables when running on Vast.ai
- add comments on recommended ports and model paths in `secrets.env.example`

## Testing
- `pytest -k vast_check -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a195e50c4832e8acb4c683636a764