### PR TITLE
Improve Vast.ai setup

### DIFF
--- a/scripts/setup_vast_ai.sh
+++ b/scripts/setup_vast_ai.sh
@@ -1,15 +1,31 @@
 #!/bin/bash
-# Basic setup script for Vast.ai instances
+# Setup script for Vast.ai instances
 set -e
 
-# install dependencies
-pip install -r requirements.txt
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
 
-# create directories for models and outputs
-mkdir -p INANNA_AI/models
-mkdir -p output
+# install system dependencies
+apt-get update
+apt-get install -y ffmpeg sox
+apt-get clean
 
-# placeholder model download (optional)
+# install Python packages
+pip install -r "$REPO_ROOT/requirements.txt"
+
+# create persistent directories
+mkdir -p "$REPO_ROOT/INANNA_AI/models"
+mkdir -p "$REPO_ROOT/output"
+mkdir -p "$REPO_ROOT/logs" "$REPO_ROOT/data"
+
+# download optional models
+if [ -n "${DOWNLOAD_MODELS:-}" ]; then
+    for model in $DOWNLOAD_MODELS; do
+        python "$REPO_ROOT/download_models.py" "$model" || true
+    done
+fi
+
+# backward compatibility flag
 if [ "$1" = "--download" ]; then
-    python download_models.py deepseek || true
+    python "$REPO_ROOT/download_models.py" deepseek || true
 fi

--- a/scripts/vast_start.sh
+++ b/scripts/vast_start.sh
@@ -13,7 +13,7 @@ if [ -f "$REPO_ROOT/secrets.env" ]; then
 fi
 
 if [ "$1" = "--setup" ]; then
-    bash "$SCRIPT_DIR/setup_vast_ai.sh"
+    bash "$SCRIPT_DIR/setup_vast_ai.sh" --download
     bash "$SCRIPT_DIR/setup_glm.sh"
 fi
 


### PR DESCRIPTION
## Summary
- expand `setup_vast_ai.sh` to install ffmpeg and sox
- allow model downloads via `DOWNLOAD_MODELS` env var
- create persistent `logs/` and `data/` folders
- call extended setup from `vast_start.sh` when `--setup` is used

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a1a4f26f8832ea6823a66af5dbbf5