### PR TITLE
Add system monitor service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,3 +39,12 @@ services:
     volumes:
       - ./INANNA_AI/models/Kimi-K2:/model
     restart: unless-stopped
+
+  monitor:
+    build: .
+    command: python system_monitor.py --serve --port 8000
+    ports:
+      - "9100:8000"
+    restart: unless-stopped
+    profiles:
+      - monitor

--- a/docs/VAST_DEPLOYMENT.md
+++ b/docs/VAST_DEPLOYMENT.md
@@ -88,3 +88,15 @@ bash scripts/vast_start.sh
 ```
 
 It tails the container logs so you can monitor the startup process. When the server becomes ready the browser window automatically loads the web console, which streams audio and video via WebRTC.
+
+## View system metrics
+
+The optional `monitor` service exposes hardware statistics collected by
+`system_monitor.py`. Start it alongside the main stack with:
+
+```bash
+docker-compose up monitor
+```
+
+Once running, open `http://localhost:9100/stats` to see real‑time CPU, GPU and
+memory usage as JSON.

--- a/docs/root_chakra_overview.md
+++ b/docs/root_chakra_overview.md
@@ -18,7 +18,10 @@ Configuration values such as the log directory and default pcap path are read fr
 
 ## `system_monitor.py`
 
-`system_monitor` collects CPU, memory and network statistics via `psutil`. Run it with `--watch` to continuously print JSON formatted data or without arguments to output a single sample.
+`system_monitor` collects CPU, GPU, memory and network statistics. Run it with
+`--watch` to continuously print JSON formatted data or without arguments to
+output a single sample. Use `--serve` to expose a FastAPI endpoint at
+`/stats` for remote monitoring.
 
 ## Environment variables
 

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -4,14 +4,46 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import time
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import psutil
+from fastapi import FastAPI
+import uvicorn
+
+
+def _get_gpu_stats() -> List[Dict[str, int]]:
+    """Return GPU utilisation and memory usage via ``nvidia-smi``."""
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=utilization.gpu,memory.total,memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:
+        return []
+
+    gpus: List[Dict[str, int]] = []
+    for line in result.stdout.strip().splitlines():
+        util, total, used = [int(x.strip()) for x in line.split(",")]
+        gpus.append(
+            {
+                "utilization": util,
+                "memory_total": total,
+                "memory_used": used,
+            }
+        )
+    return gpus
 
 
 def collect_stats() -> Dict[str, Any]:
-    """Gather basic CPU, memory and network usage statistics."""
+    """Gather basic CPU, memory, network and GPU usage statistics."""
     cpu_percent = psutil.cpu_percent(interval=None)
     mem = psutil.virtual_memory()
     net = psutil.net_io_counters()
@@ -20,6 +52,7 @@ def collect_stats() -> Dict[str, Any]:
         "memory_percent": mem.percent,
         "bytes_sent": net.bytes_sent,
         "bytes_recv": net.bytes_recv,
+        "gpus": _get_gpu_stats(),
     }
 
 
@@ -33,15 +66,34 @@ def _print_stats_loop(interval: float) -> None:
         pass
 
 
+app = FastAPI()
+
+
+@app.get("/stats")
+def stats_endpoint() -> Dict[str, Any]:
+    """Return current system statistics."""
+    return collect_stats()
+
+
+def _serve(host: str, port: int) -> None:
+    """Launch FastAPI service exposing ``/stats``."""
+    uvicorn.run(app, host=host, port=port)
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="System monitor")
     parser.add_argument("--watch", action="store_true", help="continuously display stats")
     parser.add_argument(
         "--interval", type=float, default=1.0, help="refresh interval when watching"
     )
+    parser.add_argument("--serve", action="store_true", help="run FastAPI service")
+    parser.add_argument("--host", default="0.0.0.0", help="bind host when serving")
+    parser.add_argument("--port", type=int, default=8000, help="bind port when serving")
     args = parser.parse_args(argv)
 
-    if args.watch:
+    if args.serve:
+        _serve(args.host, args.port)
+    elif args.watch:
         _print_stats_loop(args.interval)
     else:
         print(json.dumps(collect_stats()))

--- a/tests/test_system_monitor.py
+++ b/tests/test_system_monitor.py
@@ -19,6 +19,9 @@ def test_collect_stats(monkeypatch):
     monkeypatch.setattr(system_monitor.psutil, "cpu_percent", lambda interval=None: 25.0)
     monkeypatch.setattr(system_monitor.psutil, "virtual_memory", lambda: Mem)
     monkeypatch.setattr(system_monitor.psutil, "net_io_counters", lambda: Net)
+    monkeypatch.setattr(
+        system_monitor, "_get_gpu_stats", lambda: [{"utilization": 90, "memory_total": 10, "memory_used": 5}]
+    )
 
     stats = system_monitor.collect_stats()
     assert stats == {
@@ -26,6 +29,7 @@ def test_collect_stats(monkeypatch):
         "memory_percent": 50.0,
         "bytes_sent": 100,
         "bytes_recv": 200,
+        "gpus": [{"utilization": 90, "memory_total": 10, "memory_used": 5}],
     }
 
 


### PR DESCRIPTION
## Summary
- extend `system_monitor.py` with GPU stats and optional FastAPI server
- support new monitor service in `docker-compose.yml`
- document monitoring endpoints
- adjust tests for updated stats

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a203e2390832eadc6cee6e556ad26