### PR TITLE
Add update and restart script

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -91,7 +91,19 @@ Establezca en `secrets.env` las URLs de cada servicio con la IP pública de la
 instancia, por ejemplo `GLM_API_URL=http://<ip>:8001`. Ajuste de igual forma
 `DEEPSEEK_URL`, `MISTRAL_URL` y `KIMI_K2_URL` si están activos.
 
+### Actualizar y reiniciar contenedores
+
+Para actualizar el servidor ejecuta:
+
+```bash
+bash scripts/update_and_restart.sh
+```
+
+Este script realiza `git pull`, instala las dependencias de `requirements.txt` y reinicia los contenedores definidos en `docker-compose.yml`.
+
+
 ## Script overview
+
 
 - **`INANNA_AI_AGENT/inanna_ai.py`** – Activation agent that loads source texts and can recite the INANNA birth chant or feed hex data into the QNL engine. Use `--list` to show available texts.
 - **`INANNA_AI/main.py`** – Voice loop controller with optional personalities. Includes `fetch-gutenberg` and `fetch-github` subcommands to collect learning data.

--- a/scripts/update_and_restart.sh
+++ b/scripts/update_and_restart.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Update repository, install dependencies and restart containers
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+printf "Updating repository...\n"
+git pull
+
+printf "Installing dependencies...\n"
+pip install -r requirements.txt
+
+printf "Restarting containers...\n"
+docker-compose pull
+docker-compose down
+docker-compose up -d
+
+printf "Done.\n"


### PR DESCRIPTION
## Summary
- add `update_and_restart.sh` helper
- document how to use the script in `README_OPERATOR.md`

## Testing
- `pytest -k 'not gpu'` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a21666cb4832ebb0c80b10ec43d0d