### PR TITLE
Update Vast deployment docs

### DIFF
--- a/docs/VAST_DEPLOYMENT.md
+++ b/docs/VAST_DEPLOYMENT.md
@@ -1,8 +1,10 @@
 # Vast.ai Deployment
 
 This guide explains how to run the SPIRAL_OS tools on a Vast.ai server.
-
 See [deployment_overview.md](deployment_overview.md) for a quick summary.
+
+Before you begin run `scripts/check_prereqs.sh` to ensure Docker, `nc`, `sox` and
+`ffmpeg` are available. The script exits with an error if any command is missing.
 
 ## Select a PyTorch template
 
@@ -12,47 +14,21 @@ See [deployment_overview.md](deployment_overview.md) for a quick summary.
 
 ## Clone the repository and install requirements
 
-After connecting to the server run:
+After connecting to the server, run the commands below. Replace `your-user` with
+your GitHub name.
 
 ```bash
-# clone the project
 git clone https://github.com/your-user/SPIRAL_OS.git
 cd SPIRAL_OS
-
-# install Python packages
-pip install -r requirements.txt
-```
-
-Optionally install the development requirements with:
-
-```bash
-pip install -r dev-requirements.txt
-```
-
-## GPU setup and model downloads (optional)
-
-If your instance provides a GPU you can pull model weights. The helper script
-below creates directories and fetches models for you:
-
-```bash
-bash scripts/setup_vast_ai.sh
-```
-
-The script installs dependencies, prepares the `INANNA_AI/models` folder and can
-invoke `download_models.py` to pull large checkpoints. Edit the script to suit
-your needs.
-
-## Initialize GLM environment
-
-Run the setup script to install Python packages and create core directories under `/`:
-
-```bash
+bash scripts/setup_vast_ai.sh --download
 bash scripts/setup_glm.sh
 ```
 
-It prepares `/INANNA_AI`, `/QNL_LANGUAGE` and `/audit_logs`. The script copies
-`ETHICS_GUIDELINES.md` into the first two directories so the guidelines are
-always available on the server.
+The `setup_vast_ai.sh` script installs dependencies and downloads common models.
+`setup_glm.sh` prepares `/INANNA_AI`, `/QNL_LANGUAGE` and `/audit_logs`.
+Development tools can be installed with `bash scripts/setup_dev.sh` if desired.
+
+
 
 ## Clone a private repository
 
@@ -66,28 +42,39 @@ The script clones the repository to `/INANNA_AI/repo` and writes `confirmation.t
 
 ## Start the services
 
-Create a `secrets.env` file or copy the example and fill in the API keys:
+1. Copy the example file and provide the required API keys:
 
-```bash
-cp secrets.env.example secrets.env
-# edit secrets.env
-```
+   ```bash
+   cp secrets.env.example secrets.env
+   # edit secrets.env
+   ```
 
-Launch the stack with the helper script. Pass `--setup` on the first run to prepare directories:
+2. Boot the stack. The first run should include `--setup`:
 
-```bash
-bash scripts/vast_start.sh --setup
-```
+   ```bash
+   bash scripts/vast_start.sh --setup
+   ```
 
-The script reads `secrets.env`, runs the setup scripts when `--setup` is supplied and then executes `docker-compose up` for the `INANNA_AI` service. It waits for port `8000` and then calls `python -m webbrowser` to open `web_console/index.html` so you can issue commands.
+   The script loads `secrets.env`, installs missing components and waits for
+   port `8000` before opening the web console.
 
-After the first setup you can start or restart the services by running the script without any arguments:
+3. Subsequent restarts are simplified:
 
-```bash
-bash scripts/vast_start.sh
-```
+   ```bash
+   bash scripts/vast_start.sh
+   ```
 
-It tails the container logs so you can monitor the startup process. When the server becomes ready the browser window automatically loads the web console, which streams audio and video via WebRTC.
+4. Verify that the API responds correctly:
+
+   ```bash
+   python scripts/vast_check.py http://localhost:8000
+   ```
+
+   For a broader check across all configured models run
+   `bash scripts/check_services.sh`.
+
+To update the environment and restart the containers later use
+`bash scripts/update_and_restart.sh`.
 
 ## View system metrics
 

--- a/docs/deployment_overview.md
+++ b/docs/deployment_overview.md
@@ -25,21 +25,41 @@ Models are stored under `INANNA_AI/models`.
 
 ## Launch on Vast.ai
 
-Use `scripts/vast_start.sh` to spin up Spiral OS on a Vast.ai rental. On the first run pass `--setup` so the helper scripts prepare the environment and pull models:
+Follow the steps below to start Spiral OS on a Vast.ai instance.
 
-```bash
-bash scripts/vast_start.sh --setup
-```
+1. Optionally verify that Docker and other tools are available:
 
-The script loads `secrets.env`, runs `docker-compose up` for the `INANNA_AI` service, waits for port `8000` and then opens `web_console/index.html` in your browser. Subsequent runs can omit `--setup`.
+   ```bash
+   bash scripts/check_prereqs.sh
+   ```
 
-Once running you can verify that the API endpoints respond correctly with the checker script:
+2. Boot the stack for the first time. The `--setup` flag installs packages
+   and downloads any configured models:
 
-```bash
-python scripts/vast_check.py http://localhost:8000
-```
+   ```bash
+   bash scripts/vast_start.sh --setup
+   ```
 
-The checker polls `/health` and `/ready` and performs a dummy `/offer` exchange. It exits with a non‑zero status if any step fails.
+   The script reads `secrets.env`, brings up the `INANNA_AI` container and
+   waits for port `8000` before opening `web_console/index.html` in your
+   browser.
+
+3. Subsequent restarts require only:
+
+   ```bash
+   bash scripts/vast_start.sh
+   ```
+
+4. Check that the API endpoints respond correctly:
+
+   ```bash
+   python scripts/vast_check.py http://localhost:8000
+   ```
+
+   The checker polls `/health` and `/ready` and performs a dummy `/offer`
+   exchange. It exits with a non‑zero status if any step fails.
+
+To update the repository in place run `bash scripts/update_and_restart.sh`.
 
 ## Local Docker Compose
 


### PR DESCRIPTION
## Summary
- expand `deployment_overview.md` with numbered instructions
- document more helper scripts in `VAST_DEPLOYMENT.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash scripts/vast_start.sh --setup` *(fails: 403 Forbidden from apt repositories)*

------
https://chatgpt.com/codex/tasks/task_e_687a2298db38832e9978a6453b85c0a5