### PR TITLE
Add creative console CLI

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -680,3 +680,14 @@ os-guardian plan "open the browser"
 
 See [docs/os_guardian.md](docs/os_guardian.md) for an overview of the
 perception, action, planning and safety modules.
+
+## Creative Tools
+
+`creative-console` collects a few standalone helpers for audio generation.
+
+```bash
+creative-console music "lofi beat" --model riffusion
+creative-console ritual --emotion joy --symbol \u2609
+creative-console qnl-song --hex deadbeef
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dev = [
 
 [project.scripts]
 os-guardian = "os_guardian.cli:main"
+creative-console = "tools.creative_console:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tools/creative_console.py
+++ b/tools/creative_console.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Command line tools for creative music experiments."""
+
+import argparse
+from pathlib import Path
+import json
+
+from music_generation import generate_from_text
+from play_ritual_music import compose_ritual_music
+from qnl_engine import hex_to_song
+from scipy.io.wavfile import write
+
+
+
+def _cmd_music(args: argparse.Namespace) -> None:
+    path = generate_from_text(args.prompt, args.model)
+    print(path)
+
+
+def _cmd_ritual(args: argparse.Namespace) -> None:
+    out = compose_ritual_music(args.emotion, args.symbol, hide=args.stego)
+    print(out)
+
+
+def _cmd_qnl_song(args: argparse.Namespace) -> None:
+    phrases, waveform = hex_to_song(args.hex)
+    print(json.dumps(phrases, indent=2, ensure_ascii=False))
+    if waveform.size:
+        out_file = Path("qnl_song.wav")
+        write(out_file, 44100, waveform)
+        print(out_file)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Creative music utilities")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    music_p = sub.add_parser("music", help="Generate music from text")
+    music_p.add_argument("prompt", help="Description of the desired music")
+    music_p.add_argument(
+        "--model",
+        choices=["musicgen", "riffusion", "musenet"],
+        default="musicgen",
+        help="Model to use",
+    )
+    music_p.set_defaults(func=_cmd_music)
+
+    ritual_p = sub.add_parser("ritual", help="Compose ritual music")
+    ritual_p.add_argument("--emotion", required=True, help="Emotion driving the tone")
+    ritual_p.add_argument("--symbol", required=True, help="Ritual symbol")
+    ritual_p.add_argument("--stego", action="store_true", help="Hide ritual phrase")
+    ritual_p.set_defaults(func=_cmd_ritual)
+
+    qnl_p = sub.add_parser("qnl-song", help="Generate a QNL song from hex")
+    qnl_p.add_argument("--hex", required=True, help="Hexadecimal string")
+    qnl_p.set_defaults(func=_cmd_qnl_song)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()


### PR DESCRIPTION
## Summary
- implement `creative-console` with music, ritual and qnl-song subcommands
- expose the console as an entry point in `pyproject.toml`
- document usage in README_OPERATOR under new Creative Tools section

## Testing
- `pytest tests/test_music_generation.py -q`
- `pytest tests/test_play_ritual_music.py::test_play_ritual_music_cli -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a2715d8e8832eb7dcb67714aceeea