### PR TITLE
Add YAML policy file for OS Guardian

### DIFF
--- a/docs/os_guardian.md
+++ b/docs/os_guardian.md
@@ -8,3 +8,30 @@ The OS Guardian coordinates system automation under strict policy control. It co
 4. **Safety** – checks permissions for commands, domains and applications while tracking undo callbacks.
 
 These modules can be invoked individually or through the ``os-guardian`` command line interface.
+
+## Policy File
+
+Permissions may also be configured in a YAML policy referenced by the
+``OG_POLICY_FILE`` environment variable. The file supports allowlists and simple
+rate limits:
+
+```yaml
+policy: ask                        # allow, ask or deny actions
+allowed_commands:
+  - echo
+  - ls
+command_limits:
+  rm:
+    max: 1                         # once per day
+    window: 86400                  # seconds
+allowed_domains:
+  - example.com
+domain_limits:
+  example.com:
+    max: 5                         # five visits per hour
+    window: 3600
+```
+
+Set ``OG_POLICY_FILE=/path/to/policy.yaml`` before launching the tools so the
+safety module can enforce these limits.
+

--- a/os_guardian/action_engine.py
+++ b/os_guardian/action_engine.py
@@ -7,6 +7,7 @@ import shlex
 import subprocess
 from pathlib import Path
 from typing import Optional, Sequence
+from urllib.parse import urlparse
 
 from . import safety
 
@@ -81,6 +82,7 @@ def run_command(cmd: str | Sequence[str]) -> subprocess.CompletedProcess[str] | 
         return None
     try:
         proc = subprocess.run(args, capture_output=True, text=True, check=False)
+        safety.record_command(binary)
         return proc
     except OSError as exc:  # pragma: no cover - OS dependent
         logger.error("Failed to run %s: %s", binary, exc)
@@ -98,6 +100,7 @@ def open_url(
         return None
     drv = driver or webdriver.Firefox()
     drv.get(url)
+    safety.record_domain(urlparse(url).hostname or "")
     safety.register_undo(lambda: getattr(drv, "quit", lambda: None)())
     return drv
 
@@ -125,3 +128,4 @@ __all__ = [
     "open_url",
     "run_js",
 ]
+

--- a/os_guardian/planning.py
+++ b/os_guardian/planning.py
@@ -27,7 +27,7 @@ except Exception:  # pragma: no cover - optional dependency
     Document = None  # type: ignore
     FAISS = None  # type: ignore
 
-from . import action_engine, perception
+from . import action_engine, perception, safety
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +85,7 @@ class GuardianPlanner:
     llm: ChatOpenAI | None = None
 
     def __post_init__(self) -> None:  # pragma: no cover - init
+        safety.load_policy()
         if self.llm is None and ChatOpenAI is not None:
             self.llm = ChatOpenAI(temperature=0)
         self.memory = _load_memory(self.memory_path)
@@ -140,3 +141,4 @@ def plan(command: str) -> List[str]:
 
 
 __all__ = ["plan", "GuardianPlanner"]
+

--- a/os_guardian/safety.py
+++ b/os_guardian/safety.py
@@ -2,11 +2,19 @@ from __future__ import annotations
 
 """Permission checks and rollback helpers for OS Guardian actions."""
 
+import json
 import logging
 import os
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Iterable, List
 from urllib.parse import urlparse
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -19,15 +27,94 @@ if not _ALLOWED_COMMANDS:
 _ALLOWED_APPS = set(filter(None, os.environ.get("OG_ALLOWED_APPS", "").split(os.pathsep)))
 _ALLOWED_DOMAINS = set(filter(None, os.environ.get("OG_ALLOWED_DOMAINS", "").split(os.pathsep)))
 
+
+@dataclass
+class LimitPolicy:
+    """Rate limit configuration for a command or domain."""
+
+    max_calls: int
+    window: int = 86400
+    history: list[float] = field(default_factory=list)
+
+    def allowed(self) -> bool:
+        now = time.time()
+        self.history = [t for t in self.history if now - t < self.window]
+        return len(self.history) < self.max_calls
+
+    def record(self) -> None:
+        now = time.time()
+        self.history.append(now)
+        self.history = [t for t in self.history if now - t < self.window]
+
+
+_COMMAND_LIMITS: dict[str, LimitPolicy] = {}
+_DOMAIN_LIMITS: dict[str, LimitPolicy] = {}
+
 _POLICY = os.environ.get("OG_POLICY", "allow").lower()  # allow, ask or deny
 
 # Simple stack of undo callbacks
 _UNDO_STACK: List[Callable[[], None]] = []
 
 
+def load_policy(path: str | Path | None = None) -> None:
+    """Load YAML policy from ``path`` or ``OG_POLICY_FILE`` env var."""
+
+    global _POLICY
+    path = Path(path or os.environ.get("OG_POLICY_FILE", ""))
+    if not path.is_file():
+        return
+    try:
+        text = path.read_text(encoding="utf-8")
+        data = yaml.safe_load(text) if yaml is not None else json.loads(text)
+    except Exception as exc:  # pragma: no cover - parse failure
+        logger.error("Failed to load policy file %s: %s", path, exc)
+        return
+
+    _POLICY = str(data.get("policy", _POLICY)).lower()
+    _ALLOWED_COMMANDS.update(data.get("allowed_commands", []))
+    _ALLOWED_APPS.update(data.get("allowed_apps", []))
+    _ALLOWED_DOMAINS.update(data.get("allowed_domains", []))
+
+    for name, spec in data.get("command_limits", {}).items():
+        try:
+            max_calls = int(
+                spec.get("max")
+                or spec.get("max_calls")
+                or spec.get("max_per_day")
+            )
+            window = int(spec.get("window") or spec.get("window_seconds", 86400))
+            _COMMAND_LIMITS[name] = LimitPolicy(max_calls=max_calls, window=window)
+        except Exception:
+            continue
+
+    for domain, spec in data.get("domain_limits", {}).items():
+        try:
+            max_calls = int(
+                spec.get("max")
+                or spec.get("max_calls")
+                or spec.get("max_per_day")
+            )
+            window = int(spec.get("window") or spec.get("window_seconds", 86400))
+            _DOMAIN_LIMITS[domain] = LimitPolicy(max_calls=max_calls, window=window)
+        except Exception:
+            continue
+
+
 def command_allowed(cmd: str) -> bool:
     """Return ``True`` if shell command ``cmd`` is permitted."""
-    return cmd in _ALLOWED_COMMANDS
+    if _ALLOWED_COMMANDS and cmd not in _ALLOWED_COMMANDS:
+        return False
+    limit = _COMMAND_LIMITS.get(cmd)
+    if limit and not limit.allowed():
+        logger.warning("Command %s exceeds limit", cmd)
+        return False
+    return True
+
+
+def record_command(cmd: str) -> None:
+    """Record usage of shell command ``cmd`` for rate limiting."""
+    if cmd in _COMMAND_LIMITS:
+        _COMMAND_LIMITS[cmd].record()
 
 
 def app_allowed(path: str | Path) -> bool:
@@ -37,9 +124,21 @@ def app_allowed(path: str | Path) -> bool:
 
 
 def domain_allowed(url: str) -> bool:
-    """Return ``True`` if ``url`` is within an allowed domain."""
+    """Return ``True`` if ``url`` is within an allowed domain and under limits."""
     host = urlparse(url).hostname or ""
-    return not _ALLOWED_DOMAINS or host in _ALLOWED_DOMAINS
+    if _ALLOWED_DOMAINS and host not in _ALLOWED_DOMAINS:
+        return False
+    limit = _DOMAIN_LIMITS.get(host)
+    if limit and not limit.allowed():
+        logger.warning("Domain %s exceeds limit", host)
+        return False
+    return True
+
+
+def record_domain(host: str) -> None:
+    """Record usage of domain ``host`` for rate limiting."""
+    if host in _DOMAIN_LIMITS:
+        _DOMAIN_LIMITS[host].record()
 
 
 def confirm(prompt: str) -> bool:
@@ -79,10 +178,16 @@ def undo_all() -> None:
 
 __all__ = [
     "command_allowed",
+    "record_command",
     "app_allowed",
     "domain_allowed",
+    "record_domain",
     "confirm",
     "register_undo",
     "undo_last",
     "undo_all",
+    "load_policy",
 ]
+
+load_policy()
+

--- a/tests/test_os_guardian_policy.py
+++ b/tests/test_os_guardian_policy.py
@@ -1,0 +1,68 @@
+import importlib
+import os
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# dummy libs
+pyautogui = types.ModuleType("pyautogui")
+pyautogui.click = lambda *a, **k: None
+pyautogui.typewrite = lambda *a, **k: None
+pyautogui.scroll = lambda *a, **k: None
+sys.modules["pyautogui"] = pyautogui
+
+class DummyDriver:
+    def get(self, url):
+        pass
+
+webdriver = types.SimpleNamespace(Firefox=lambda: DummyDriver())
+selenium = types.ModuleType("selenium")
+selenium.webdriver = webdriver
+sys.modules["selenium"] = selenium
+sys.modules["selenium.webdriver"] = webdriver
+
+
+def test_yaml_policy_limits(tmp_path, monkeypatch):
+    policy = tmp_path / "policy.yaml"
+    policy.write_text(
+        "{"
+        "\"policy\": \"allow\"," \
+        " \"allowed_commands\": [\"foo\"]," \
+        " \"command_limits\": {\"foo\": {\"max\": 1}}," \
+        " \"allowed_domains\": [\"example.com\"]," \
+        " \"domain_limits\": {\"example.com\": {\"max\": 1}}" \
+        "}"
+    )
+    monkeypatch.setenv("OG_POLICY_FILE", str(policy))
+
+    safety = importlib.import_module("os_guardian.safety")
+    importlib.reload(safety)
+    action_engine = importlib.import_module("os_guardian.action_engine")
+    importlib.reload(action_engine)
+
+    calls = []
+
+    def fake_run(a, capture_output=True, text=True, check=False):
+        calls.append(list(a))
+        class CP:
+            def __init__(self):
+                self.args = a
+                self.stdout = "ok"
+        return CP()
+
+    monkeypatch.setattr(action_engine.subprocess, "run", fake_run)
+    monkeypatch.setattr(action_engine.safety, "register_undo", lambda f: None)
+    res1 = action_engine.run_command(["foo"])
+    res2 = action_engine.run_command(["foo"])
+    assert res1 is not None
+    assert res2 is None
+    assert calls == [["foo"]]
+
+    drv1 = action_engine.open_url("http://example.com")
+    drv2 = action_engine.open_url("http://example.com")
+    assert drv1 is not None
+    assert drv2 is None
+


### PR DESCRIPTION
## Summary
- extend `safety` with YAML policy loader and rate limiting
- track command/domain usage and record after actions
- load policy in planner init
- update docs with new policy format
- add tests for policy limits

## Testing
- `pytest tests/test_os_guardian*.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687a2a4166f0832eba4a696cf63e0ec0