### PR TITLE
Add OS Guardian execution bridge

### DIFF
--- a/crown_prompt_orchestrator.py
+++ b/crown_prompt_orchestrator.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 import asyncio
 
 from state_transition_engine import StateTransitionEngine
+from os_guardian import execute_instruction
 
 from INANNA_AI.glm_integration import GLMIntegration
 from INANNA_AI import emotion_analysis
@@ -46,6 +47,11 @@ async def _delegate(prompt: str, glm: GLMIntegration) -> str:
 
 def crown_prompt_orchestrator(message: str, glm: GLMIntegration) -> Dict[str, Any]:
     """Return GLM or servant model reply with metadata."""
+    stripped = message.strip()
+    if stripped.startswith("/osg"):
+        command = stripped[len("/osg"):].lstrip()
+        execute_instruction(command)
+        return {"action": "os_guardian", "command": command}
     emotion = _detect_emotion(message)
     archetype = emotion_analysis.emotion_to_archetype(emotion)
     weight = emotion_analysis.emotion_weight(emotion)

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -54,6 +54,7 @@ from tools import reflection_loop
 from INANNA_AI import listening_engine
 import vector_memory
 import archetype_shift_engine
+from os_guardian import execute_instruction
 
 # Emotion to model lookup derived from docs/crown_manifest.md
 _EMOTION_MODEL_MATRIX = {
@@ -343,6 +344,11 @@ class MoGEOrchestrator:
 
     def handle_input(self, text: str) -> Dict[str, Any]:
         """Parse ``text`` as QNL, update mood and delegate to :meth:`route`."""
+        stripped = text.strip()
+        if stripped.startswith("/osg"):
+            command = stripped[len("/osg"):].lstrip()
+            execute_instruction(command)
+            return {"action": "os_guardian", "command": command}
         # Detect simple command phrases
         for intent in task_parser.parse(text):
             action = intent.get("action")

--- a/os_guardian/__init__.py
+++ b/os_guardian/__init__.py
@@ -1,5 +1,47 @@
 """Utilities for operating system automation."""
 
 from . import action_engine, perception, planning, cli
+from corpus_memory_logging import log_interaction
+import ast
 
-__all__ = ["action_engine", "perception", "planning", "cli"]
+
+def _run_action(step: str) -> None:
+    """Execute a single action step produced by :mod:`planning`."""
+    name, _, remainder = step.partition("(")
+    args_str = remainder.rsplit(")", 1)[0]
+    args = []
+    kwargs = {}
+    if args_str.strip():
+        try:  # parse arguments safely
+            dummy_call = ast.parse(f"f({args_str})", mode="eval").body  # type: ignore
+            args = [ast.literal_eval(a) for a in getattr(dummy_call, "args", [])]
+            kwargs = {
+                kw.arg: ast.literal_eval(kw.value)
+                for kw in getattr(dummy_call, "keywords", [])
+                if kw.arg
+            }
+        except Exception:
+            return
+    func = getattr(action_engine, name.strip(), None)
+    if callable(func):
+        try:
+            func(*args, **kwargs)
+        except Exception:  # pragma: no cover - best effort execution
+            pass
+
+
+def execute_instruction(text: str) -> list[str]:
+    """Plan ``text`` and execute resulting actions."""
+    steps = planning.plan(text)
+    for step in steps:
+        _run_action(step)
+    log_interaction(text, {"action": "os_guardian"}, {"plan": steps}, "ok")
+    return steps
+
+__all__ = [
+    "action_engine",
+    "perception",
+    "planning",
+    "cli",
+    "execute_instruction",
+]

--- a/tests/test_os_guardian_bridge.py
+++ b/tests/test_os_guardian_bridge.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+import types
+
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+dummy_np = types.ModuleType("numpy")
+dummy_np.clip = lambda val, lo, hi: val
+dummy_np.mean = lambda arr: 0
+sys.modules.setdefault("numpy", dummy_np)
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from crown_prompt_orchestrator import crown_prompt_orchestrator
+import os_guardian
+import corpus_memory_logging as cml
+
+
+class DummyGLM:
+    def complete(self, prompt: str, quantum_context: str | None = None) -> str:
+        return prompt
+
+
+def test_osg_directive(monkeypatch):
+    recorded = {}
+    monkeypatch.setattr(os_guardian.planning, "plan", lambda text: recorded.setdefault("plan", text) or ["type_text('hi')"])
+    calls = []
+    monkeypatch.setattr(os_guardian.action_engine, "type_text", lambda txt: calls.append(txt))
+    log_calls = []
+    monkeypatch.setattr(cml, "log_interaction", lambda i, intent, res, o, **k: log_calls.append(intent))
+
+    glm = DummyGLM()
+    result = crown_prompt_orchestrator("/osg greet", glm)
+
+    assert recorded["plan"] == "greet"
+    assert calls == ["hi"]
+    assert log_calls and log_calls[0] == {"action": "os_guardian"}
+    assert result["action"] == "os_guardian"


### PR DESCRIPTION
## Summary
- add `execute_instruction` to `os_guardian` for running planned actions
- allow `/osg` commands in crown orchestrators
- log invocations of OS Guardian actions
- test bridging through the prompt orchestrator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a2c90f4c8832e8cf3956f4a859543