### PR TITLE
Add ritual training daemon

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -535,6 +535,17 @@ python auto_retrain.py --run
 This prints novelty and coherence scores and invokes the API when conditions are
 met.
 
+## Continuous Learning
+
+Set `RITUAL_TRAIN_INTERVAL` (minutes) to control how often `ritual_trainer.py`
+checks for new insights. Start the background loop with:
+
+```bash
+scripts/run_ritual_training.sh &
+```
+
+The script saves the process ID to `ritual_training.pid`.
+
 ## Verify core integrity
 
 At any point you may confirm that the RFA7D grid has not been tampered with:

--- a/ritual_trainer.py
+++ b/ritual_trainer.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
+import time
 from pathlib import Path
 from typing import Any, Iterable, List
 
@@ -40,26 +42,40 @@ def build_dataset(entries: Iterable[dict[str, Any]]) -> List[dict[str, Any]]:
     return dataset
 
 
-def run_training(run: bool) -> None:
-    entries = spiral_cortex_memory.load_insights()
-    processed = _load_state()
-    new_entries = entries[processed:]
-    if len(new_entries) >= THRESHOLD and auto_retrain.system_idle():
-        dataset = build_dataset(new_entries)
-        if run:
-            auto_retrain.trigger_finetune(dataset)
-            _save_state(len(entries))
+def run_training(run: bool, loop: bool = False, max_cycles: int | None = None) -> None:
+    """Check for new insights and optionally fine-tune in a loop."""
+    interval = float(os.getenv("RITUAL_TRAIN_INTERVAL", "10"))
+    cycles = 0
+    while True:
+        entries = spiral_cortex_memory.load_insights()
+        processed = _load_state()
+        new_entries = entries[processed:]
+        if len(new_entries) >= THRESHOLD and auto_retrain.system_idle():
+            dataset = build_dataset(new_entries)
+            if run:
+                auto_retrain.trigger_finetune(dataset)
+                _save_state(len(entries))
+            else:
+                logger.info(json.dumps(dataset, indent=2))
         else:
-            logger.info(json.dumps(dataset, indent=2))
-    else:
-        logger.info("Conditions not met")
+            logger.info("Conditions not met")
+
+        if not loop:
+            break
+        cycles += 1
+        if max_cycles is not None and cycles >= max_cycles:
+            break
+        time.sleep(interval * 60)
 
 
 def main(argv: list[str] | None = None) -> None:  # pragma: no cover - CLI entry
     parser = argparse.ArgumentParser(description="Retrain from spiral insights")
     parser.add_argument("--run", action="store_true", help="Execute training")
+    parser.add_argument(
+        "--loop", action="store_true", help="Run continuously at the set interval"
+    )
     args = parser.parse_args(argv)
-    run_training(args.run)
+    run_training(args.run, loop=args.loop)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual run

--- a/scripts/run_ritual_training.sh
+++ b/scripts/run_ritual_training.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Start the ritual training loop in the background
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+python ritual_trainer.py --run --loop >/dev/null 2>&1 &
+PID=$!
+echo $PID > ritual_training.pid
+printf "Ritual training started (PID %s)\n" "$PID"

--- a/tests/test_ritual_training.py
+++ b/tests/test_ritual_training.py
@@ -1,0 +1,44 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import types
+
+dummy_np = types.ModuleType("numpy")
+dummy_np.array = lambda x, dtype=None: x
+dummy_np.asarray = lambda x: x
+dummy_np.linalg = types.SimpleNamespace(norm=lambda v: 1.0)
+dummy_np.ndarray = list
+dummy_np.float32 = float
+sys.modules.setdefault("numpy", dummy_np)
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+
+import ritual_trainer
+import spiral_cortex_memory as scm
+import auto_retrain
+
+
+def test_training_loop_triggers(tmp_path, monkeypatch):
+    mem_file = tmp_path / "mem.jsonl"
+    state_file = tmp_path / "state.json"
+    entry = {"question": "q", "snippets": [{"snippet": "s"}], "sentiment": 0.0}
+    mem_file.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+
+    monkeypatch.setattr(scm, "INSIGHT_FILE", mem_file)
+    monkeypatch.setattr(ritual_trainer, "STATE_FILE", state_file)
+    monkeypatch.setattr(ritual_trainer, "THRESHOLD", 1)
+
+    calls = []
+    monkeypatch.setattr(auto_retrain, "system_idle", lambda: True)
+    monkeypatch.setattr(auto_retrain, "trigger_finetune", lambda ds: calls.append(ds))
+
+    monkeypatch.setenv("RITUAL_TRAIN_INTERVAL", "0")
+    monkeypatch.setattr(ritual_trainer.time, "sleep", lambda s: None)
+
+    ritual_trainer.run_training(True, loop=True, max_cycles=1)
+
+    assert calls


### PR DESCRIPTION
## Summary
- loop `ritual_trainer.run_training` with `RITUAL_TRAIN_INTERVAL`
- add `--loop` CLI flag
- provide `scripts/run_ritual_training.sh` helper
- document continuous learning in the operator guide
- test daemon logic

## Testing
- `pytest tests/test_ritual_training.py tests/test_spiral_cortex_memory.py::test_trainer_triggers -q`

------
https://chatgpt.com/codex/tasks/task_e_687a2ee40d64832e984a0a36cf5bf001