### PR TITLE
Update console and OS Guardian docs

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -545,6 +545,8 @@ scripts/run_ritual_training.sh &
 ```
 
 The script saves the process ID to `ritual_training.pid`.
+`auto_retrain.py` can also be scheduled via `cron` to fine-tune the model
+whenever `data/feedback.json` exceeds the `RETRAIN_THRESHOLD` value.
 
 ## Verify core integrity
 
@@ -644,6 +646,15 @@ frames. For guidance on customizing the avatar textures edit
 `guides/avatar_config.toml` as described in
 [`docs/avatar_pipeline.md`](docs/avatar_pipeline.md).
 
+Within the console you can adjust the system state with a few slash commands:
+
+```
+/emotion joy      # update the current emotion label
+/avatar dreamer   # switch to a different avatar style
+/reload           # reload the Crown agent
+```
+
+
 ## HTTP Interface
 
 `server.py` exposes a small FastAPI application with a `/glm-command` endpoint.
@@ -680,6 +691,11 @@ container script:
 pip install .[dev]
 bash scripts/setup_os_guardian.sh
 ```
+
+Set ``OG_POLICY`` to ``allow``, ``ask`` or ``deny`` and point ``OG_POLICY_FILE``
+at a YAML file defining ``allowed_commands``, ``allowed_apps`` and rate limits.
+``OG_ALLOWED_COMMANDS``, ``OG_ALLOWED_APPS`` and ``OG_ALLOWED_DOMAINS`` may also
+be provided directly. See ``docs/os_guardian_permissions.md`` for details.
 
 Once inside the container the ``os-guardian`` command exposes basic tools:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,11 @@
 
 The `docs` directory contains reference material for Spiral OS.
 
-Milestone VIII expands on the sovereign voice work with memory-aided routing and a new session logger. See [milestone_viii_plan.md](milestone_viii_plan.md) for the design and [../README_OPERATOR.md](../README_OPERATOR.md) for updated commands.
+Milestone VIII expands on the sovereign voice work with memory-aided routing and
+a new session logger. See [milestone_viii_plan.md](milestone_viii_plan.md) for
+the design and [../README_OPERATOR.md](../README_OPERATOR.md) for updated
+commands including the avatar and creative consoles. The OS Guardian policy
+format is detailed in [os_guardian.md](os_guardian.md).
 
 - [ALBEDO_LAYER.md](ALBEDO_LAYER.md)
 - [CORPUS_MEMORY.md](CORPUS_MEMORY.md)

--- a/docs/os_guardian.md
+++ b/docs/os_guardian.md
@@ -35,3 +35,17 @@ domain_limits:
 Set ``OG_POLICY_FILE=/path/to/policy.yaml`` before launching the tools so the
 safety module can enforce these limits.
 
+## Environment variables
+
+The safety layer also reads the following variables:
+
+- ``OG_POLICY`` – default permission mode: ``allow``, ``ask`` or ``deny``.
+- ``OG_ALLOWED_COMMANDS`` – colon‑separated list of shell commands that may run.
+- ``OG_ALLOWED_APPS`` – colon‑separated list of application paths.
+- ``OG_ALLOWED_DOMAINS`` – colon‑separated list of domains permitted in
+  ``open_url``.
+
+These overrides are merged with any values found in the policy file.
+See [os_guardian_permissions.md](os_guardian_permissions.md) for a full
+explanation of the safety framework.
+


### PR DESCRIPTION
## Summary
- document emotion and avatar console commands
- explain OG policy environment variables
- mention avatar/creative consoles in docs index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `./start_avatar_console.sh` *(fails: Missing required command(s): docker sox ffmpeg)*
- `python -m os_guardian.cli click 10 10`

------
https://chatgpt.com/codex/tasks/task_e_687a306bbba8832ebe4873d2b26bae8f