### PR TITLE
Reference GLM_API_URL in docstrings

### DIFF
--- a/INANNA_AI/existential_reflector.py
+++ b/INANNA_AI/existential_reflector.py
@@ -1,4 +1,4 @@
-"""Generate a short self-description using a placeholder GLM endpoint."""
+"""Generate a short self-description using the GLM endpoint from ``GLM_API_URL``."""
 from __future__ import annotations
 
 import logging

--- a/INANNA_AI/glm_analyze.py
+++ b/INANNA_AI/glm_analyze.py
@@ -1,4 +1,4 @@
-"""Analyze Python modules using a placeholder GLM endpoint."""
+"""Analyze Python modules using the GLM endpoint from ``GLM_API_URL``."""
 from __future__ import annotations
 
 import logging

--- a/INANNA_AI/glm_init.py
+++ b/INANNA_AI/glm_init.py
@@ -1,4 +1,4 @@
-"""Summarize project purpose using a placeholder GLM endpoint."""
+"""Summarize project purpose using the GLM endpoint configured via ``GLM_API_URL``."""
 from __future__ import annotations
 
 import logging

--- a/INANNA_AI/glm_integration.py
+++ b/INANNA_AI/glm_integration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Wrapper around a placeholder GLM-4.1V-9B endpoint."""
+"""Wrapper around the GLM endpoint defined by ``GLM_API_URL``."""
 
 import logging
 import os


### PR DESCRIPTION
## Summary
- update GLM module docstrings to mention GLM_API_URL instead of a placeholder endpoint

## Testing
- `pytest -k "glm_integration or glm_init or glm_analyze or existential_reflector" -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a3554f908832ea6315e41a6aa8dca