### PR TITLE
Add stop script for Crown console

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -599,6 +599,12 @@ console and streaming server, and wait for both processes:
 python start_crown_console.py
 ```
 
+Stop all services and the video stream with:
+
+```bash
+scripts/stop_crown_console.sh
+```
+
 After initialization the console displays the prompt:
 
 ```

--- a/scripts/stop_crown_console.sh
+++ b/scripts/stop_crown_console.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Stop Crown services and video stream.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+stop_container() {
+    local name="$1"
+    if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -wq "$name"; then
+        docker stop "$name" >/dev/null
+        echo "Stopped container $name"
+    fi
+}
+
+stop_pid() {
+    local file="$1"
+    if [ -f "$file" ]; then
+        local pid
+        pid=$(cat "$file")
+        if kill "$pid" 2>/dev/null; then
+            echo "Stopped process $pid from $file"
+        fi
+        rm -f "$file"
+    fi
+}
+
+stop_container glm_service
+stop_container deepseek_service
+stop_container mistral_service
+stop_container kimi_k2_service
+
+for f in glm_service.pid deepseek_service.pid mistral_service.pid kimi_k2_service.pid video_stream.pid; do
+    stop_pid "$f"
+done
+
+pkill -f video_stream.py 2>/dev/null || true
+pkill -f openai.api_server 2>/dev/null || true
+
+printf 'Crown services terminated.\n'


### PR DESCRIPTION
## Summary
- add `stop_crown_console.sh` script to stop models and video stream
- document script usage in operator guide

## Testing
- `pytest tests/test_crown_console_startup.py tests/test_start_crown_console_py.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687a37a25e34832eb5d1952ec9f6de67