### PR TITLE
Add failing GLM endpoint test

### DIFF
--- a/tests/test_crown_console_startup.py
+++ b/tests/test_crown_console_startup.py
@@ -54,3 +54,97 @@ def test_crown_console_startup(monkeypatch):
 
     assert launcher_idx < servants_idx
     assert servants_idx < port_idx < check_idx < console_idx
+
+
+def test_crown_console_dead_glm(monkeypatch, tmp_path):
+    monkeypatch.syspath_prepend(str(ROOT))
+
+    yaml_mod = types.ModuleType("yaml")
+    yaml_mod.safe_load = lambda *a, **k: {}
+    monkeypatch.setitem(sys.modules, "yaml", yaml_mod)
+
+    dummy_np = types.ModuleType("numpy")
+    dummy_np.ndarray = object
+    dummy_np.zeros = lambda *a, **k: None
+    dummy_np.pi = 3.14159
+    dummy_np.float32 = float
+    monkeypatch.setitem(sys.modules, "numpy", dummy_np)
+
+    sf_mod = types.ModuleType("soundfile")
+    sf_mod.write = lambda *a, **k: None
+    sf_mod.read = lambda *a, **k: (b"", 22050)
+    monkeypatch.setitem(sys.modules, "soundfile", sf_mod)
+
+    librosa_mod = types.ModuleType("librosa")
+    librosa_mod.load = lambda *a, **k: ([], 22050)
+    librosa_mod.resample = lambda *a, **k: []
+    librosa_mod.effects = types.SimpleNamespace(
+        pitch_shift=lambda *a, **k: [], time_stretch=lambda *a, **k: []
+    )
+    monkeypatch.setitem(sys.modules, "librosa", librosa_mod)
+
+    monkeypatch.setitem(sys.modules, "opensmile", types.ModuleType("opensmile"))
+
+    scipy_mod = types.ModuleType("scipy")
+    scipy_io_mod = types.ModuleType("scipy.io")
+    scipy_wavfile_mod = types.ModuleType("scipy.io.wavfile")
+    scipy_wavfile_mod.write = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "scipy", scipy_mod)
+    monkeypatch.setitem(sys.modules, "scipy.io", scipy_io_mod)
+    monkeypatch.setitem(sys.modules, "scipy.io.wavfile", scipy_wavfile_mod)
+
+    stable_mod = types.ModuleType("stable_baselines3")
+    stable_mod.PPO = type("DummyPPO", (), {"__init__": lambda self, *a, **k: None})
+    monkeypatch.setitem(sys.modules, "stable_baselines3", stable_mod)
+
+    gym_mod = types.ModuleType("gymnasium")
+    gym_mod.Env = object
+    spaces_mod = types.ModuleType("spaces")
+    spaces_mod.Box = type("DummyBox", (), {"__init__": lambda self, *a, **k: None})
+    gym_mod.spaces = spaces_mod
+    monkeypatch.setitem(sys.modules, "gymnasium", gym_mod)
+
+    monkeypatch.setitem(
+        sys.modules, "SPIRAL_OS.qnl_engine", types.ModuleType("SPIRAL_OS.qnl_engine")
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "SPIRAL_OS.symbolic_parser",
+        types.ModuleType("SPIRAL_OS.symbolic_parser"),
+    )
+
+    import init_crown_agent
+    import INANNA_AI.glm_integration as gi
+
+    monkeypatch.setattr(init_crown_agent, "_load_config", lambda: {})
+    monkeypatch.setattr(init_crown_agent, "_init_servants", lambda c: None)
+    monkeypatch.setattr(init_crown_agent.vector_memory, "_get_collection", lambda: None)
+    monkeypatch.setattr(
+        init_crown_agent.corpus_memory, "create_collection", lambda dir_path=None: None
+    )
+
+    class ConnErr(Exception):
+        pass
+
+    def raise_conn(*_a, **_k):
+        raise ConnErr("fail")
+
+    dummy_requests = types.SimpleNamespace(post=raise_conn, RequestException=ConnErr)
+    monkeypatch.setattr(gi, "requests", dummy_requests)
+
+    monkeypatch.setenv("GLM_API_URL", "http://localhost:9999")
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[0] == "bash" and str(cmd[1]).endswith("start_crown_console.sh"):
+            try:
+                init_crown_agent.initialize_crown()
+            except SystemExit as exc:
+                return subprocess.CompletedProcess(cmd, exc.code, "", "")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = subprocess.run(["bash", str(ROOT / "start_crown_console.sh")])
+
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
- extend crown console startup tests with failing GLM endpoint case

## Testing
- `pytest tests/test_crown_console_startup.py::test_crown_console_dead_glm -q`
- `pytest tests/test_crown_console_startup.py::test_crown_console_startup -q`
- `pytest tests/test_crown_console_startup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687a38bb8564832e9de70601ccd7a388