### PR TITLE
docs: note new console startup checks

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -585,8 +585,10 @@ start the servant models without relaunching the main GLM service.
 ./launch_servants.sh
 ```
 
-Use `start_crown_console.sh` to launch these services and automatically
-open the interactive console once the endpoints are ready.
+Use `start_crown_console.sh` to launch these services. The script first
+invokes `scripts/check_prereqs.sh` to verify that Docker, `nc`, `sox` and
+`ffmpeg` are available, then automatically opens the interactive console once
+the endpoints are ready.
 
 ```bash
 ./start_crown_console.sh
@@ -604,6 +606,9 @@ Stop all services and the video stream with:
 ```bash
 scripts/stop_crown_console.sh
 ```
+
+This stop script terminates running containers, removes any saved PID files
+and cleans up stray processes related to the Crown console.
 
 After initialization the console displays the prompt:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,3 +49,6 @@ format is detailed in [os_guardian.md](os_guardian.md).
 - [spiritual_architecture.md](spiritual_architecture.md)
 
 Recent updates add tests for the fallback text-to-speech helper and verify connectivity to the GLM service during initialization.
+The startup script `start_crown_console.sh` now checks for Docker, `nc`, `sox`
+and `ffmpeg` via `scripts/check_prereqs.sh` before launching. Use
+`scripts/stop_crown_console.sh` to terminate all processes when shutting down.


### PR DESCRIPTION
## Summary
- document new console prereq check and stop script

## Testing
- `pytest` *(fails: FileNotFoundError)*
- `./start_crown_console.sh` *(fails: Missing required command(s))*
- `scripts/stop_crown_console.sh`


------
https://chatgpt.com/codex/tasks/task_e_687a3b612934832ea617443c6fd38441