### PR TITLE
Add env variable validation for crown console

### DIFF
--- a/start_crown_console.py
+++ b/start_crown_console.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 
 from dotenv import load_dotenv
+from env_validation import check_required
 
 
 ROOT = Path(__file__).resolve().parent
@@ -16,6 +17,7 @@ ROOT = Path(__file__).resolve().parent
 def main() -> None:
     """Launch console and video stream then wait for exit."""
     load_dotenv(ROOT / "secrets.env")
+    check_required(["GLM_API_URL", "GLM_API_KEY", "HF_TOKEN"])
 
     crown_proc = subprocess.Popen(["bash", str(ROOT / "start_crown_console.sh")])
     stream_proc = subprocess.Popen([sys.executable, str(ROOT / "video_stream.py")])

--- a/start_crown_console.sh
+++ b/start_crown_console.sh
@@ -13,6 +13,10 @@ if [ -f "secrets.env" ]; then
     # shellcheck source=/dev/null
     source "secrets.env"
     set +a
+    python - <<'EOF'
+import env_validation
+env_validation.check_required(["GLM_API_URL", "GLM_API_KEY", "HF_TOKEN"])
+EOF
 else
     echo "secrets.env not found" >&2
     exit 1

--- a/tests/test_start_crown_console_py.py
+++ b/tests/test_start_crown_console_py.py
@@ -17,6 +17,7 @@ def test_python_crown_console(monkeypatch):
     dummy_dotenv = types.SimpleNamespace(load_dotenv=lambda *_: None)
     monkeypatch.setitem(sys.modules, "dotenv", dummy_dotenv)
     loader.exec_module(mod)
+    monkeypatch.setattr(mod, "check_required", lambda v: None)
 
     def fake_sleep(_):
         # Simulate one loop iteration


### PR DESCRIPTION
## Summary
- ensure GLM_API_URL, GLM_API_KEY and HF_TOKEN are set when starting Crown console
- verify required variables inside the Python wrapper as well
- adjust startup tests to check for missing variable failure

## Testing
- `pytest tests/test_crown_console_startup.py::test_crown_console_missing_env -q`
- `pytest tests/test_start_crown_console_py.py::test_python_crown_console -q`
- `pytest tests/test_env_validation.py -q`
- `pytest tests/test_crown_console_startup.py tests/test_start_crown_console_py.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687a403e8ce4832e81f54531a7f18581