### PR TITLE
Add polling health checks for Crown services

### DIFF
--- a/start_crown_console.sh
+++ b/start_crown_console.sh
@@ -66,13 +66,15 @@ parse_port() {
 
 main_port=$(parse_port "$GLM_API_URL")
 wait_port "$main_port"
+./scripts/check_services.sh "$GLM_API_URL"
 
 for url in "${DEEPSEEK_URL:-}" "${MISTRAL_URL:-}" "${KIMI_K2_URL:-}"; do
-    if [[ "$url" == http://localhost:* || "$url" == http://127.0.0.1:* ]]; then
-        wait_port "$(parse_port "$url")"
+    if [ -n "$url" ]; then
+        if [[ "$url" == http://localhost:* || "$url" == http://127.0.0.1:* ]]; then
+            wait_port "$(parse_port "$url")"
+        fi
+        ./scripts/check_services.sh "$url"
     fi
 done
-
-./scripts/check_services.sh
 
 python console_interface.py


### PR DESCRIPTION
## Summary
- retry `/health` and `/ready` checks in `check_services.sh`
- wait for each service individually in `start_crown_console.sh`

## Testing
- `bash -n scripts/check_services.sh`
- `bash -n start_crown_console.sh`
- `pytest -k check_services -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687a42620a8c832e856d8f3a128c7dac